### PR TITLE
Clion IDE 용 devcontainer 설정 및 gitignore 대상 추가

### DIFF
--- a/.devcontainer/clion/Dockerfile
+++ b/.devcontainer/clion/Dockerfile
@@ -1,0 +1,39 @@
+# CLion용 Dev Container도 기존 Pintos 환경과 같은 이미지를 사용하도록
+# 루트 .devcontainer/Dockerfile을 거의 그대로 복제합니다.
+FROM --platform=linux/amd64 ubuntu:22.04
+
+ENV TZ=Asia/Seoul LANG=ko_KR.UTF-8 LANGUAGE=ko_KR.UTF-8
+
+# Build / debug / qemu 실행에 필요한 기본 도구만 기존과 동일하게 설치합니다.
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update \
+    # && echo "tzdata tzdata/Areas select Asia" | debconf-set-selections \
+    # && echo "tzdata tzdata/Zones/Asia select Seoul" | debconf-set-selections \
+    && apt-get install -y \
+    locales tzdata \
+    build-essential \
+    gcc \
+    gdb \
+    vim \
+    git \
+    sudo \
+    qemu-system-x86 \
+    python3 \
+    && locale-gen ko_KR.UTF-8 && update-locale LANG=ko_KR.UTF-8
+# && apt-get clean \
+# && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash jungle && usermod -aG sudo jungle
+RUN echo "jungle ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/jungle
+
+USER jungle
+WORKDIR /home/jungle
+
+# CLion backend가 여는 터미널에서도 기존 VSCode Dev Container와 동일하게
+# Pintos activate 스크립트가 자동 적용되도록 같은 경로를 유지합니다.
+RUN echo "source /workspaces/pintos_22.04_lab_docker/pintos/activate" >> /home/jungle/.bashrc
+
+# Clone the repository
+# RUN git clone https://github.com/casys-kaist/pintos-kaist /home/jungle/pintos
+
+# Set default shell for the `jungle` user

--- a/.devcontainer/clion/README.md
+++ b/.devcontainer/clion/README.md
@@ -1,0 +1,146 @@
+# Pintos CLion 개발 가이드
+
+이 저장소는 `.devcontainer` 기반 사용만 지원합니다. 문서는 CLion + Dev Container 기준으로만 설명합니다.
+
+## 준비물
+
+- Docker Desktop
+- CLion
+- JetBrains Dev Containers 사용 가능 환경
+
+## 시작하기
+
+프로젝트를 받은 뒤 CLion에서 저장소 루트를 엽니다.
+
+```bash
+git clone --depth=1 https://github.com/krafton-jungle/pintos_22.04_lab_docker.git
+cd pintos_22.04_lab_docker
+```
+
+CLion에서는 JetBrains Dev Containers로 `.devcontainer/clion/devcontainer.json`을 선택해 컨테이너를 생성합니다.
+
+- 처음 빌드에는 시간이 걸릴 수 있습니다.
+- 컨테이너 내부 작업 디렉터리는 `/workspaces/pintos_22.04_lab_docker`입니다.
+- 컨테이너 터미널은 `pintos/activate`를 자동으로 읽도록 설정되어 있습니다.
+
+`pintos` 명령이 잡히지 않으면 한 번만 아래를 실행하면 됩니다.
+
+```bash
+source /workspaces/pintos_22.04_lab_docker/pintos/activate
+```
+
+## 기본 작업 위치
+
+주차별 기본 디렉터리는 아래와 같습니다.
+
+```bash
+cd /workspaces/pintos_22.04_lab_docker/pintos/threads   # Project 1
+# cd /workspaces/pintos_22.04_lab_docker/pintos/userprog  # Project 2
+# cd /workspaces/pintos_22.04_lab_docker/pintos/vm        # Project 3
+```
+
+## 빌드와 테스트
+
+가장 기본적인 작업 순서는 아래와 같습니다.
+
+```bash
+cd /workspaces/pintos_22.04_lab_docker/pintos/threads
+make
+make check
+```
+
+특정 테스트만 실행하려면 `build` 디렉터리에서 실행합니다.
+
+```bash
+cd /workspaces/pintos_22.04_lab_docker/pintos/threads/build
+make tests/threads/alarm-zero.result
+```
+
+자주 쓰는 예시는 아래와 같습니다.
+
+```bash
+cd /workspaces/pintos_22.04_lab_docker/pintos/threads
+make
+
+cd /workspaces/pintos_22.04_lab_docker/pintos/threads/build
+pintos -- run alarm-multiple
+```
+
+## CLion 디버거 사용법
+
+가장 단순한 방식은 터미널에서 QEMU를 `gdb stub` 모드로 띄운 뒤, CLion이 원격 디버거로 attach 하는 방식입니다.
+
+### 1. 커널 빌드
+
+```bash
+cd /workspaces/pintos_22.04_lab_docker/pintos/threads
+make
+```
+
+### 2. QEMU를 디버그 대기 상태로 실행
+
+```bash
+cd /workspaces/pintos_22.04_lab_docker/pintos/threads/build
+pintos --gdb -- run alarm-multiple
+```
+
+이 명령은 QEMU를 실행한 뒤 디버거 연결을 기다립니다. 터미널이 멈춘 것처럼 보여도 정상입니다.
+
+### 3. CLion에서 Remote Debug 설정 선택
+
+이 저장소에는 CLion Remote Debug 설정이 `.idea/runConfigurations/Pintos_Remote_Debug.xml`로 포함되어 있습니다. CLion 상단 실행 설정에서 `Pintos Remote Debug`를 선택하면 됩니다.
+
+설정값은 아래와 같습니다.
+
+- `Debugger`: `GDB`
+- `Target`: `tcp:127.0.0.1:1234`
+- `Symbol file`: `/workspaces/pintos_22.04_lab_docker/pintos/threads/build/kernel.o`
+
+중요:
+
+- 심볼 파일은 `kernel.bin`이 아니라 `kernel.o`를 사용해야 합니다.
+- `pintos --gdb`는 QEMU를 `1234` 포트에서 대기시키므로 CLion도 같은 포트로 붙어야 합니다.
+
+### 4. 브레이크포인트 후 디버그 시작
+
+소스에 브레이크포인트를 건 뒤 CLion에서 `Pintos Remote Debug` 설정을 실행합니다.
+
+처음에는 아래 위치가 확인하기 쉽습니다.
+
+- `threads/init.c`
+- `threads/thread.c`
+- `devices/timer.c`
+
+CLion이 attach 되면 `Resume`으로 커널 실행을 이어갈 수 있습니다.
+
+## 디버깅 예시 명령
+
+```bash
+cd /workspaces/pintos_22.04_lab_docker/pintos/threads
+make
+
+cd /workspaces/pintos_22.04_lab_docker/pintos/threads/build
+pintos --gdb -- run alarm-zero
+```
+
+이후 CLion `Pintos Remote Debug`에서 `kernel.o`에 attach 하면 됩니다.
+
+## 문제 해결
+
+`pintos` 명령이 없을 때:
+
+```bash
+source /workspaces/pintos_22.04_lab_docker/pintos/activate
+```
+
+CLion이 attach 하지 못할 때:
+
+- `pintos --gdb -- ...`가 먼저 실행되어 있어야 합니다.
+- CLion 실행 설정이 `Pintos Remote Debug`인지 확인합니다.
+- `Pintos Remote Debug`의 `Target`이 `tcp:127.0.0.1:1234`인지 확인합니다.
+- `Pintos Remote Debug`의 `Symbol file`이 현재 빌드한 `kernel.o`인지 확인합니다.
+
+브레이크포인트가 맞지 않을 때:
+
+- `make`를 다시 실행합니다.
+- `threads/build/kernel.o` 경로가 맞는지 확인합니다.

--- a/.devcontainer/clion/devcontainer.json
+++ b/.devcontainer/clion/devcontainer.json
@@ -1,0 +1,16 @@
+{
+    "name": "pintos-dev-clion",
+    "dockerFile": "Dockerfile",
+    "remoteUser": "jungle",
+
+    // CLion에서도 기존 activate 경로를 그대로 쓰기 위해 workspace 경로를 고정합니다.
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/pintos_22.04_lab_docker,type=bind",
+    "workspaceFolder": "/workspaces/pintos_22.04_lab_docker",
+
+    "customizations": {
+        "jetbrains": {
+            // JetBrains Dev Containers가 CLion backend를 실행하도록 지정합니다.
+            "backend": "CLion"
+        }
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Created by https://www.toptal.com/developers/gitignore/api/c,c++,jetbrains+all,windows,macos,cmake,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=c,c++,jetbrains+all,windows,macos,cmake,visualstudiocode
+
+### C ###
 # Prerequisites
 *.d
 
@@ -11,7 +15,6 @@
 *.ilk
 *.map
 *.exp
-*.lst
 
 # Precompiled Headers
 *.gch
@@ -29,26 +32,19 @@
 *.so.*
 *.dylib
 
-# Executables and images
+# Executables
 *.exe
 *.out
 *.app
 *.i*86
 *.x86_64
 *.hex
-*.bin
-*.img
-*.qemu
-*.raw
-*.dis
-*.dump
 
 # Debug files
 *.dSYM/
 *.su
 *.idb
 *.pdb
-*.log
 
 # Kernel Module Compile Results
 *.mod*
@@ -59,19 +55,245 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
-# Build directories
+### C++ ###
+# Prerequisites
+
+# Compiled Object files
+*.slo
+
+# Precompiled Headers
+
+# Compiled Dynamic libraries
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+
+# Executables
+
+### CMake ###
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+### CMake Patch ###
+CMakeUserPresets.json
+
+# External projects
+*-prefix/
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/c,c++,jetbrains+all,windows,macos,cmake,visualstudiocode
+
+
+# Pintos 빌드 중간 파일 및 산출물
+*.o
+*.d
+*.out
+*.bin
+*.elf
+*.img
+*.map
+*.lst
+*.log
+*.qemu
+*.raw
+*.hex
+*.dis
+*.dump
+
+# 빌드 디렉터리
 **/build/
 **/bin/
 **/obj/
 **/output/
+# core dump
+core
 
-# Temporary files
+# 임시 파일
 *~
 *.swp
-core
 
 # macOS
 .DS_Store
 
-# debug information files
-*.dwo
+# JetBrains IDE
+.idea/*
+!.idea/runConfigurations/
+!.idea/runConfigurations/*.xml

--- a/.idea/runConfigurations/Pintos_Remote_Debug.xml
+++ b/.idea/runConfigurations/Pintos_Remote_Debug.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Pintos Remote Debug" type="RsRemoteRunConfiguration" factoryName="Remote Debug" debuggerKind="GDB" remoteCommand="tcp:127.0.0.1:1234" symbolFile="/workspaces/pintos_22.04_lab_docker/pintos/threads/build/kernel.o" sysroot="">
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
### 배경

저는 Clion IDE를 사용하기 때문에, 기존의 VSCode 용 `devcontainer.json`을 사용할 수 없습니다.

### 작업

- `.devcontainer/clion/` 디렉토리를 생성하고, 해당 위치에 CLion IDE에 맞는 devcontainer 설정을 별도로 추가
- CLion 구성 파일이 코드에 불필요하게 포함될 수 있으므로, 해당 구성요소가 Git으로 관리되지 않도록 `.gitignore`에 추가

### 변경사항

이 PR로 추가된 설정은 VSCode를 사용하는 기존 사용자나 코드에 영향을 주지 않습니다.