### PR TITLE
feat(thread): Alarm Clock & Priority Scheduling 

### DIFF
--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -88,11 +88,12 @@ timer_elapsed (int64_t then) {
 /* 약 TICKS 타이머 틱 동안 실행을 일시 중지합니다. */
 void
 timer_sleep (int64_t ticks) {
-	int64_t start = timer_ticks ();
-
+	ASSERT (!intr_context ());
 	ASSERT (intr_get_level () == INTR_ON);
-	while (timer_elapsed (start) < ticks)
-		thread_yield ();
+
+	if (ticks <= 0)
+		return;
+	thread_sleep (timer_ticks () + ticks);
 }
 
 /* 약 MS밀리초 동안 실행을 일시 중지합니다. */
@@ -124,6 +125,7 @@ static void
 timer_interrupt (struct intr_frame *args UNUSED) {
 	ticks++;
 	thread_tick ();
+	threads_wakeup (ticks);
 }
 
 /* LOOPS번 반복하는 동안 타이머 틱이 하나 넘게 지나면 true,

--- a/pintos/include/lib/kernel/list.h
+++ b/pintos/include/lib/kernel/list.h
@@ -140,9 +140,18 @@ bool list_empty (struct list *);
 /* 여러 가지 잡다한. */
 void list_reverse (struct list *);
 
-/* 주어진 두 목록 요소 A와 B의 값을 비교합니다.
-   보조 데이터 AUX. A가 B보다 작으면 true를 반환합니다.
-   A가 B보다 크거나 같으면 false입니다. */
+/* 주어진 두 목록 요소 A와 B를 AUX 보조 데이터와 함께 비교한다.
+   true를 반환하면 A가 B보다 앞에 와야 한다.
+   false를 반환하면 A가 B보다 앞에 오지 않는다. 즉, B가 A보다 앞서거나 같다.
+
+   A와 B가 같은 값일 때, 앞에서 탐색한다고 가정하면
+   true를 반환하면 앞에 붙어서 항상 먼저 찾아진다.
+   false를 반환하면 같은 값 요소들의 뒤에 붙어서 round-robin 순서를 유지한다.
+
+   구현체 네이밍 기준:
+   {name}_less: 값이 작은 것이 앞에 위치한다.
+   {name}_more: 값이 큰 것이 앞에 위치한다. 큰 값을 작은 것으로 처리하므로
+                min은 가장 큰 값, max는 가장 작은 값을 반환한다. */
 typedef bool list_less_func (const struct list_elem *a,
                              const struct list_elem *b,
                              void *aux);

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -162,5 +162,7 @@ void do_iret (struct intr_frame *tf);
 
 bool cmp_priority (const struct list_elem *a,
 		const struct list_elem *b, void *aux UNUSED);
+bool cmp_donors_priority (const struct list_elem *a,
+		const struct list_elem *b, void *aux UNUSED);
 
 #endif /* threads/thread.h */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -103,7 +103,8 @@ struct thread {
 	/* 특정 락에 대기하고 있는 경우, 그 락을 바라본다. 그 외에는 NULL. */
 	struct lock *wait_on_lock;
 
-	/* d_elem 요소를 가짐. Donors(후원자)의 목록, Multiple Donation 표현 */
+	/* d_elem 요소를 가짐.
+	   Donors(후원자)의 목록, Multiple Donation 표현. 정렬 순서를 보장하지 않음 */
 	struct list donations;
 
 	/* donations로 관리되는 리스트, elem과는 별개로 관리되어야 하므로 필요함 */
@@ -160,9 +161,9 @@ int thread_get_load_avg (void);
 
 void do_iret (struct intr_frame *tf);
 
-bool cmp_priority (const struct list_elem *a,
+bool cmp_priority_more (const struct list_elem *a,
 		const struct list_elem *b, void *aux UNUSED);
-bool cmp_donors_priority (const struct list_elem *a,
+bool cmp_donors_priority_more (const struct list_elem *a,
 		const struct list_elem *b, void *aux UNUSED);
 void refresh_priority_in_donors (void);
 

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -164,5 +164,6 @@ bool cmp_priority (const struct list_elem *a,
 		const struct list_elem *b, void *aux UNUSED);
 bool cmp_donors_priority (const struct list_elem *a,
 		const struct list_elem *b, void *aux UNUSED);
+void refresh_priority_in_donors (void);
 
 #endif /* threads/thread.h */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -4,6 +4,7 @@
 #include <debug.h>
 #include <list.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include "threads/interrupt.h"
 #ifdef VM
 #include "vm/vm.h"
@@ -96,6 +97,18 @@ struct thread {
 	/* thread.c와 synch.c 간에 공유됩니다. */
 	struct list_elem elem;              /* 목록 요소. */
 
+	/* priority는 Donation으로 변하기 때문에, 순수하게 해당 스레드의 priority를 저장하는 역할 */
+	int base_priority;
+
+	/* 특정 락에 대기하고 있는 경우, 그 락을 바라본다. 그 외에는 NULL. */
+	struct lock *wait_on_lock;
+
+	/* d_elem 요소를 가짐. Donors(후원자)의 목록, Multiple Donation 표현 */
+	struct list donations;
+
+	/* donations로 관리되는 리스트, elem과는 별개로 관리되어야 하므로 필요함 */
+	struct list_elem d_elem;
+
 #ifdef USERPROG
 	/* userprog/process.c가 소유합니다. */
 	uint64_t *pml4;                     /* 페이지 맵 레벨 4 */
@@ -133,6 +146,7 @@ const char *thread_name (void);
 
 void thread_exit (void) NO_RETURN;
 void thread_yield (void);
+void thread_yield_if_needed (void);
 void thread_sleep (int64_t wakeup_tick);
 void threads_wakeup (int64_t ticks);
 
@@ -145,5 +159,8 @@ int thread_get_recent_cpu (void);
 int thread_get_load_avg (void);
 
 void do_iret (struct intr_frame *tf);
+
+bool cmp_priority (const struct list_elem *a,
+		const struct list_elem *b, void *aux UNUSED);
 
 #endif /* threads/thread.h */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -91,6 +91,7 @@ struct thread {
 	enum thread_status status;          /* 스레드 상태. */
 	char name[16];                      /* 이름(디버깅용). */
 	int priority;                       /* 우선순위. */
+	int64_t wakeup_ticks;               /* 깨워야 할 타이머 tick. */
 
 	/* thread.c와 synch.c 간에 공유됩니다. */
 	struct list_elem elem;              /* 목록 요소. */
@@ -132,6 +133,8 @@ const char *thread_name (void);
 
 void thread_exit (void) NO_RETURN;
 void thread_yield (void);
+void thread_sleep (int64_t wakeup_tick);
+void threads_wakeup (int64_t ticks);
 
 int thread_get_priority (void);
 void thread_set_priority (int);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -260,16 +260,7 @@ lock_release (struct lock *lock) {
 		}
 	}
 
-	cur->priority = cur->base_priority;
-
-	if (!list_empty (&cur->donations)) {
-		int max_priority = list_entry (list_min (&cur->donations,
-				cmp_donors_priority, NULL), struct thread, d_elem)->priority;
-
-		if (cur->priority < max_priority) {
-			cur->priority = max_priority;
-		}
-	}
+	refresh_priority_in_donors ();
 
 	lock->holder = NULL;
 	sema_up (&lock->semaphore);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -65,7 +65,7 @@ sema_down (struct semaphore *sema) {
 	old_level = intr_disable ();
 	while (sema->value == 0) {
 		list_insert_ordered (&sema->waiters, &thread_current ()->elem,
-				cmp_priority, NULL);
+				cmp_priority_more, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -109,7 +109,7 @@ sema_up (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	if (!list_empty (&sema->waiters)) {
-		list_sort (&sema->waiters, cmp_priority, NULL); // Priority Donation 때문
+		list_sort (&sema->waiters, cmp_priority_more, NULL); // Priority Donation 때문
 		thread_unblock (list_entry (list_pop_front (&sema->waiters),
 					struct thread, elem));
 	}

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -195,13 +195,11 @@ lock_acquire (struct lock *lock) {
 	if (holder != NULL) {
 		cur->wait_on_lock = lock;
 		list_push_back (&holder->donations, &cur->d_elem);
-		if (holder->priority < cur->priority) {
-			holder->priority = cur->priority;
-		}
 
+		// lock holder 체인의 끝(편의상 root)까지 순회하며 이동
 		struct thread *t = holder;
-		while (t != NULL) { // 끝(wait_on_lock이 없는 스레드)까지 가야 함.
-			if (t->priority < cur->priority) { // 중간에 큰 값이 있어도 멈추지 않고, 작으면 갱신
+		while (t != NULL) {
+			if (t->priority < cur->priority) { // 내 우선순위보다 작으면 갱신
 				t->priority = cur->priority;
 			}
 			if (t->wait_on_lock == NULL) {

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -204,7 +204,6 @@ lock_acquire (struct lock *lock) {
 			if (t->priority < cur->priority) { // 중간에 큰 값이 있어도 멈추지 않고, 작으면 갱신
 				t->priority = cur->priority;
 			}
-			t->priority = cur->priority;
 			if (t->wait_on_lock == NULL) {
 				break;
 			}
@@ -265,7 +264,7 @@ lock_release (struct lock *lock) {
 
 	if (!list_empty (&cur->donations)) {
 		int max_priority = list_entry (list_min (&cur->donations,
-				cmp_priority, NULL), struct thread, d_elem)->priority;
+				cmp_donors_priority, NULL), struct thread, d_elem)->priority;
 
 		if (cur->priority < max_priority) {
 			cur->priority = max_priority;

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -28,8 +28,8 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 
-static bool cmp_sema_priority(const struct list_elem* a,
-		const struct list_elem* b,
+static bool cmp_sema_priority (const struct list_elem *a,
+		const struct list_elem *b,
 		void *aux UNUSED);
 
 /* 세마포어 SEMA을 VALUE로 초기화합니다. 세마포어는
@@ -109,12 +109,12 @@ sema_up (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	if (!list_empty (&sema->waiters)) {
-		list_sort (&sema->waiters, cmp_priority, NULL); // Priority Donation 떄문
+		list_sort (&sema->waiters, cmp_priority, NULL); // Priority Donation 때문
 		thread_unblock (list_entry (list_pop_front (&sema->waiters),
 					struct thread, elem));
 	}
 	sema->value++;
-	thread_yield_if_needed();
+	thread_yield_if_needed ();
 	intr_set_level (old_level);
 }
 
@@ -194,7 +194,7 @@ lock_acquire (struct lock *lock) {
 	struct thread *cur = thread_current ();
 	if (holder != NULL) {
 		cur->wait_on_lock = lock;
-		list_push_back(&holder->donations, &cur->d_elem);
+		list_push_back (&holder->donations, &cur->d_elem);
 		if (holder->priority < cur->priority) {
 			holder->priority = cur->priority;
 		}
@@ -251,19 +251,19 @@ lock_release (struct lock *lock) {
 
 	struct list_elem *e;
 	e = list_begin (&cur->donations);
-	while (e != list_end(&cur->donations)) {
-		struct thread *t = list_entry(e, struct thread, d_elem);
+	while (e != list_end (&cur->donations)) {
+		struct thread *t = list_entry (e, struct thread, d_elem);
 
 		if (t->wait_on_lock == lock) {
-			e = list_remove(e);
+			e = list_remove (e);
 		} else {
-			e = list_next(e);
+			e = list_next (e);
 		}
 	}
 
 	cur->priority = cur->base_priority;
 
-	if (!list_empty(&cur->donations)) {
+	if (!list_empty (&cur->donations)) {
 		int max_priority = list_entry (list_min (&cur->donations,
 				cmp_priority, NULL), struct thread, d_elem)->priority;
 
@@ -356,7 +356,7 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	if (!list_empty (&cond->waiters)) {
-		list_sort (&cond->waiters, cmp_sema_priority, NULL);//Priority Donation 때문
+		list_sort (&cond->waiters, cmp_sema_priority, NULL); // Priority Donation 때문
 		sema_up (&list_entry (list_pop_front (&cond->waiters),
 					struct semaphore_elem, elem)->semaphore);
 	}
@@ -379,7 +379,7 @@ cond_broadcast (struct condition *cond, struct lock *lock) {
 
 
 static bool
-cmp_sema_priority(const struct list_elem* a, const struct list_elem* b,
+cmp_sema_priority (const struct list_elem *a, const struct list_elem *b,
 		void *aux UNUSED) {
 	struct semaphore_elem *sa = list_entry (a, struct semaphore_elem, elem);
 	struct semaphore_elem *sb = list_entry (b, struct semaphore_elem, elem);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -28,6 +28,10 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 
+static bool cmp_sema_priority(const struct list_elem* a,
+		const struct list_elem* b,
+		void *aux UNUSED);
+
 /* 세마포어 SEMA을 VALUE로 초기화합니다. 세마포어는
    음이 아닌 정수와 두 개의 원자 연산자
    조작하기:
@@ -60,7 +64,8 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		list_insert_ordered (&sema->waiters, &thread_current ()->elem,
+				cmp_priority, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -103,10 +108,13 @@ sema_up (struct semaphore *sema) {
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
+	if (!list_empty (&sema->waiters)) {
+		list_sort (&sema->waiters, cmp_priority, NULL); // Priority Donation 떄문
 		thread_unblock (list_entry (list_pop_front (&sema->waiters),
 					struct thread, elem));
+	}
 	sema->value++;
+	thread_yield_if_needed();
 	intr_set_level (old_level);
 }
 
@@ -182,8 +190,31 @@ lock_acquire (struct lock *lock) {
 	ASSERT (!intr_context ());
 	ASSERT (!lock_held_by_current_thread (lock));
 
+	struct thread *holder = lock->holder;
+	struct thread *cur = thread_current ();
+	if (holder != NULL) {
+		cur->wait_on_lock = lock;
+		list_push_back(&holder->donations, &cur->d_elem);
+		if (holder->priority < cur->priority) {
+			holder->priority = cur->priority;
+		}
+
+		struct thread *t = holder;
+		while (t != NULL) { // 끝(wait_on_lock이 없는 스레드)까지 가야 함.
+			if (t->priority < cur->priority) { // 중간에 큰 값이 있어도 멈추지 않고, 작으면 갱신
+				t->priority = cur->priority;
+			}
+			t->priority = cur->priority;
+			if (t->wait_on_lock == NULL) {
+				break;
+			}
+			t = t->wait_on_lock->holder;
+		}
+	}
+
 	sema_down (&lock->semaphore);
-	lock->holder = thread_current ();
+	cur->wait_on_lock = NULL;
+	lock->holder = cur;
 }
 
 /* LOCK 획득을 시도하고 성공하거나 거짓인 경우 true를 반환합니다.
@@ -216,6 +247,31 @@ lock_release (struct lock *lock) {
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
 
+	struct thread *cur = thread_current ();
+
+	struct list_elem *e;
+	e = list_begin (&cur->donations);
+	while (e != list_end(&cur->donations)) {
+		struct thread *t = list_entry(e, struct thread, d_elem);
+
+		if (t->wait_on_lock == lock) {
+			e = list_remove(e);
+		} else {
+			e = list_next(e);
+		}
+	}
+
+	cur->priority = cur->base_priority;
+
+	if (!list_empty(&cur->donations)) {
+		int max_priority = list_entry (list_min (&cur->donations,
+				cmp_priority, NULL), struct thread, d_elem)->priority;
+
+		if (cur->priority < max_priority) {
+			cur->priority = max_priority;
+		}
+	}
+
 	lock->holder = NULL;
 	sema_up (&lock->semaphore);
 }
@@ -234,6 +290,8 @@ lock_held_by_current_thread (const struct lock *lock) {
 struct semaphore_elem {
 	struct list_elem elem;              /* 목록 요소. */
 	struct semaphore semaphore;         /* 이 세마포어. */
+
+	struct thread *thread;
 };
 
 /* 조건 변수 COND 을 초기화합니다. 조건 변수
@@ -276,7 +334,8 @@ cond_wait (struct condition *cond, struct lock *lock) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	sema_init (&waiter.semaphore, 0);
-	list_push_back (&cond->waiters, &waiter.elem);
+	waiter.thread = thread_current ();
+	list_insert_ordered (&cond->waiters, &waiter.elem, cmp_sema_priority, NULL);
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
 	lock_acquire (lock);
@@ -296,9 +355,11 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (!intr_context ());
 	ASSERT (lock_held_by_current_thread (lock));
 
-	if (!list_empty (&cond->waiters))
+	if (!list_empty (&cond->waiters)) {
+		list_sort (&cond->waiters, cmp_sema_priority, NULL);//Priority Donation 때문
 		sema_up (&list_entry (list_pop_front (&cond->waiters),
 					struct semaphore_elem, elem)->semaphore);
+	}
 }
 
 /* COND을(를 통해 보호되는) 대기 중인 모든 스레드를 깨웁니다.
@@ -314,4 +375,14 @@ cond_broadcast (struct condition *cond, struct lock *lock) {
 
 	while (!list_empty (&cond->waiters))
 		cond_signal (cond, lock);
+}
+
+
+static bool
+cmp_sema_priority(const struct list_elem* a, const struct list_elem* b,
+		void *aux UNUSED) {
+	struct semaphore_elem *sa = list_entry (a, struct semaphore_elem, elem);
+	struct semaphore_elem *sb = list_entry (b, struct semaphore_elem, elem);
+
+	return sa->thread->priority > sb->thread->priority;
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -376,21 +376,8 @@ threads_wakeup (int64_t ticks) {
 /* 현재 스레드의 우선순위를 NEW_PRIORITY 으로 설정합니다. */
 void
 thread_set_priority (int new_priority) {
-	struct thread *cur = thread_current ();
-
-	cur->base_priority = new_priority;
-
-	/* donations 확인해서 priority 올바르게 갱신한다. */
-	cur->priority = cur->base_priority;
-	if (!list_empty (&cur->donations)) {
-		int max_priority = list_entry (list_min (&cur->donations,
-				cmp_donors_priority, NULL), struct thread, d_elem)->priority;
-
-		if (cur->priority < max_priority) {
-			cur->priority = max_priority;
-		}
-	}
-
+	thread_current ()->base_priority = new_priority;
+	refresh_priority_in_donors ();
 	thread_yield_if_needed ();
 }
 
@@ -702,4 +689,23 @@ cmp_donors_priority (const struct list_elem *a, const struct list_elem *b,
 	const struct thread *tb = list_entry (b, struct thread, d_elem);
 
 	return ta->priority > tb->priority;
+}
+
+/* priority를 donations를 순회하면서 올바르게 보정함.
+ * donations에 변화가 생기거나,
+ * lock chain?의 root의 우선순위 변경이 발생했을 때 항상 실행되어야 함.
+ * cmp_priority 와 동일하게 큰게 앞에(작은걸로 판단) 오게 처리. */
+void refresh_priority_in_donors (void) {
+	struct thread *cur = thread_current ();
+
+	cur->priority = cur->base_priority;
+
+	if (!list_empty (&cur->donations)) {
+		int max_priority = list_entry (list_min (&cur->donations,
+				cmp_donors_priority, NULL), struct thread, d_elem)->priority;
+
+		if (cur->priority < max_priority) {
+			cur->priority = max_priority;
+		}
+	}
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -65,7 +65,7 @@ static void init_thread (struct thread *, const char *name, int priority);
 static void do_schedule (int status);
 static void schedule (void);
 static tid_t allocate_tid (void);
-static bool cmp_wakeup_ticks (const struct list_elem *a,
+static bool cmp_wakeup_ticks_less (const struct list_elem *a,
 		const struct list_elem *b, void *aux UNUSED);
 
 /* T가 유효한 스레드를 가리키는 것으로 나타나면 true를 반환합니다. */
@@ -247,7 +247,7 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	list_insert_ordered (&ready_list, &t->elem, cmp_priority, NULL);
+	list_insert_ordered (&ready_list, &t->elem, cmp_priority_more, NULL);
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -310,7 +310,7 @@ thread_yield (void) {
 
 	old_level = intr_disable ();
 	if (curr != idle_thread)
-		list_insert_ordered (&ready_list, &curr->elem, cmp_priority, NULL);
+		list_insert_ordered (&ready_list, &curr->elem, cmp_priority_more, NULL);
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
 }
@@ -321,7 +321,7 @@ thread_yield_if_needed (void) {
 	if (list_empty (&ready_list))
 		return;
 
-	list_sort (&ready_list, cmp_priority, NULL); // Priority Donation 때문
+	list_sort (&ready_list, cmp_priority_more, NULL); // Priority Donation 때문
 	struct thread *peek_t =
 		list_entry (list_front (&ready_list), struct thread, elem);
 	bool need_preemption = peek_t->priority > thread_current ()->priority;
@@ -345,7 +345,7 @@ thread_sleep (int64_t wakeup_tick) {
 	old_level = intr_disable ();
 	if (curr != idle_thread) {
 		curr->wakeup_ticks = wakeup_tick;
-		list_insert_ordered (&sleep_list, &curr->elem, cmp_wakeup_ticks, NULL);
+		list_insert_ordered (&sleep_list, &curr->elem, cmp_wakeup_ticks_less, NULL);
 		thread_block ();
 	}
 	intr_set_level (old_level);
@@ -490,7 +490,7 @@ static struct thread *
 next_thread_to_run (void) {
 	if (list_empty (&ready_list))
 		return idle_thread;
-	list_sort (&ready_list, cmp_priority, NULL); // Priority Donation 때문에 정렬 필요
+	list_sort (&ready_list, cmp_priority_more, NULL); // Priority Donation 때문에 정렬 필요
 	return list_entry (list_pop_front (&ready_list), struct thread, elem);
 }
 
@@ -660,7 +660,7 @@ allocate_tid (void) {
 }
 
 static bool
-cmp_wakeup_ticks (const struct list_elem *a, const struct list_elem *b,
+cmp_wakeup_ticks_less (const struct list_elem *a, const struct list_elem *b,
 		void *aux UNUSED) {
 	const struct thread *ta = list_entry (a, struct thread, elem);
 	const struct thread *tb = list_entry (b, struct thread, elem);
@@ -673,7 +673,7 @@ cmp_wakeup_ticks (const struct list_elem *a, const struct list_elem *b,
 
 /* 헷갈릴 수 있는데, 큰 게 앞에 위치하도록 조건을 명세의 반대로 한다. */
 bool
-cmp_priority (const struct list_elem *a, const struct list_elem *b,
+cmp_priority_more (const struct list_elem *a, const struct list_elem *b,
 		void *aux UNUSED) {
 	const struct thread *ta = list_entry (a, struct thread, elem);
 	const struct thread *tb = list_entry (b, struct thread, elem);
@@ -682,8 +682,9 @@ cmp_priority (const struct list_elem *a, const struct list_elem *b,
 	return ta->priority > tb->priority;
 }
 
+/* cmp_priority 와 동일하게 큰게 앞에(작은걸로 판단) 오게 처리. */
 bool
-cmp_donors_priority (const struct list_elem *a, const struct list_elem *b,
+cmp_donors_priority_more (const struct list_elem *a, const struct list_elem *b,
 		void *aux UNUSED) {
 	const struct thread *ta = list_entry (a, struct thread, d_elem);
 	const struct thread *tb = list_entry (b, struct thread, d_elem);
@@ -692,17 +693,17 @@ cmp_donors_priority (const struct list_elem *a, const struct list_elem *b,
 }
 
 /* priority를 donations를 순회하면서 올바르게 보정함.
- * donations에 변화가 생기거나,
- * lock chain?의 root의 우선순위 변경이 발생했을 때 항상 실행되어야 함.
- * cmp_priority 와 동일하게 큰게 앞에(작은걸로 판단) 오게 처리. */
+   donations에 변화가 생기거나,
+   lock chain?의 root의 우선순위 변경이 발생했을 때 항상 실행되어야 함. */
 void refresh_priority_in_donors (void) {
 	struct thread *cur = thread_current ();
 
 	cur->priority = cur->base_priority;
 
 	if (!list_empty (&cur->donations)) {
+		// _more 비교 함수라 min이 가장 큰 값을 반환함.
 		int max_priority = list_entry (list_min (&cur->donations,
-				cmp_donors_priority, NULL), struct thread, d_elem)->priority;
+				cmp_donors_priority_more, NULL), struct thread, d_elem)->priority;
 
 		if (cur->priority < max_priority) {
 			cur->priority = max_priority;

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -384,7 +384,7 @@ thread_set_priority (int new_priority) {
 	cur->priority = cur->base_priority;
 	if (!list_empty (&cur->donations)) {
 		int max_priority = list_entry (list_min (&cur->donations,
-				cmp_priority, NULL), struct thread, d_elem)->priority;
+				cmp_donors_priority, NULL), struct thread, d_elem)->priority;
 
 		if (cur->priority < max_priority) {
 			cur->priority = max_priority;
@@ -692,5 +692,14 @@ cmp_priority (const struct list_elem *a, const struct list_elem *b,
 	const struct thread *tb = list_entry (b, struct thread, elem);
 
 	/* 같은 priority는 false를 반환해서 기존 항목 뒤에 간다. */
+	return ta->priority > tb->priority;
+}
+
+bool
+cmp_donors_priority (const struct list_elem *a, const struct list_elem *b,
+		void *aux UNUSED) {
+	const struct thread *ta = list_entry (a, struct thread, d_elem);
+	const struct thread *tb = list_entry (b, struct thread, d_elem);
+
 	return ta->priority > tb->priority;
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -28,6 +28,9 @@
    실행할 준비가 되었지만 실제로 실행되지는 않습니다. */
 static struct list ready_list;
 
+/* 특정 타이머 tick까지 잠든 스레드 목록. */
+static struct list sleep_list;
+
 /* 유휴 스레드. */
 static struct thread *idle_thread;
 
@@ -62,6 +65,8 @@ static void init_thread (struct thread *, const char *name, int priority);
 static void do_schedule(int status);
 static void schedule (void);
 static tid_t allocate_tid (void);
+static bool cmp_wakeup_ticks (const struct list_elem *a,
+		const struct list_elem *b, void *aux UNUSED);
 
 /* T가 유효한 스레드를 가리키는 것으로 나타나면 true를 반환합니다. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
@@ -108,6 +113,7 @@ thread_init (void) {
 /* 전역 스레드 컨텍스트를 초기화한다. */
 	lock_init (&tid_lock);
 	list_init (&ready_list);
+	list_init (&sleep_list);
 	list_init (&destruction_req);
 
 	/* 실행 중인 스레드에 대한 스레드 구조를 설정합니다. */
@@ -306,6 +312,44 @@ thread_yield (void) {
 		list_push_back (&ready_list, &curr->elem);
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
+}
+
+/* WAKEUP_TICK까지 현재 스레드를 재우고 스케줄 대상에서 제외한다. */
+void
+thread_sleep (int64_t wakeup_tick) {
+	struct thread *curr = thread_current ();
+	enum intr_level old_level;
+
+	ASSERT (!intr_context ());
+
+	old_level = intr_disable ();
+	if (curr != idle_thread) {
+		curr->wakeup_ticks = wakeup_tick;
+		list_insert_ordered (&sleep_list, &curr->elem, cmp_wakeup_ticks, NULL);
+		thread_block ();
+	}
+	intr_set_level (old_level);
+}
+
+/* 깨어날 tick에 도달한 모든 sleeping thread를 ready 상태로 옮긴다. */
+void
+threads_wakeup (int64_t ticks) {
+	struct list_elem *e;
+
+	ASSERT (intr_context ());
+	ASSERT (intr_get_level () == INTR_OFF);
+
+	e = list_begin (&sleep_list);
+	while (e != list_end (&sleep_list)) {
+		struct thread *t = list_entry (e, struct thread, elem);
+
+		if (t->wakeup_ticks <= ticks) {
+			e = list_remove (e);
+			thread_unblock (t);
+		} else {
+			break;
+		}
+	}
 }
 
 /* 현재 스레드의 우선순위를 NEW_PRIORITY 으로 설정합니다. */
@@ -587,4 +631,16 @@ allocate_tid (void) {
 	lock_release (&tid_lock);
 
 	return tid;
+}
+
+static bool
+cmp_wakeup_ticks (const struct list_elem *a, const struct list_elem *b,
+		void *aux UNUSED) {
+	const struct thread *ta = list_entry (a, struct thread, elem);
+	const struct thread *tb = list_entry (b, struct thread, elem);
+
+	if (ta->wakeup_ticks == tb->wakeup_ticks)
+		return ta->priority > tb->priority;
+
+	return ta->wakeup_ticks < tb->wakeup_ticks;
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -212,6 +212,7 @@ thread_create (const char *name, int priority,
 
 	/* 실행 대기열에 추가합니다. */
 	thread_unblock (t);
+	thread_yield_if_needed();
 
 	return tid;
 }
@@ -246,7 +247,7 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	list_push_back (&ready_list, &t->elem);
+	list_insert_ordered (&ready_list, &t->elem, cmp_priority, NULL);
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -309,9 +310,28 @@ thread_yield (void) {
 
 	old_level = intr_disable ();
 	if (curr != idle_thread)
-		list_push_back (&ready_list, &curr->elem);
+		list_insert_ordered (&ready_list, &curr->elem, cmp_priority, NULL);
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
+}
+
+/* 만약 ready_list 중 현재 스레드보다 우선순위가 높은게 있으면 preemption(yield 호출) 한다. */
+void
+thread_yield_if_needed (void) {
+	if (list_empty (&ready_list))
+		return;
+
+	list_sort(&ready_list, cmp_priority, NULL); // Priority Donation 떄문
+	struct thread *peek_t =
+		list_entry (list_front (&ready_list), struct thread, elem);
+	bool need_preemption = peek_t->priority > thread_current ()->priority;
+
+	if (need_preemption) {
+		if (intr_context ())
+			intr_yield_on_return ();
+		else
+			thread_yield ();
+	}
 }
 
 /* WAKEUP_TICK까지 현재 스레드를 재우고 스케줄 대상에서 제외한다. */
@@ -350,12 +370,18 @@ threads_wakeup (int64_t ticks) {
 			break;
 		}
 	}
+	thread_yield_if_needed();
 }
 
 /* 현재 스레드의 우선순위를 NEW_PRIORITY 으로 설정합니다. */
 void
 thread_set_priority (int new_priority) {
-	thread_current ()->priority = new_priority;
+	struct thread *cur = thread_current ();
+	cur->base_priority = new_priority;
+	if (cur->priority < new_priority) {
+		cur->priority = new_priority;
+	}
+	thread_yield_if_needed();
 }
 
 /* 현재 스레드의 우선순위를 반환합니다. */
@@ -452,7 +478,10 @@ init_thread (struct thread *t, const char *name, int priority) {
 	strlcpy (t->name, name, sizeof t->name);
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
+	t->base_priority = priority;
 	t->magic = THREAD_MAGIC;
+	t->wait_on_lock = NULL;
+	list_init(&t->donations);
 }
 
 /* 예약할 다음 스레드를 선택하고 반환합니다. 해야 한다
@@ -464,8 +493,8 @@ static struct thread *
 next_thread_to_run (void) {
 	if (list_empty (&ready_list))
 		return idle_thread;
-	else
-		return list_entry (list_pop_front (&ready_list), struct thread, elem);
+	list_sort(&ready_list, cmp_priority, NULL); // Priority Donation 때매 정렬 필요
+	return list_entry (list_pop_front (&ready_list), struct thread, elem);
 }
 
 /* iretq를 사용하여 스레드 시작 */
@@ -643,4 +672,15 @@ cmp_wakeup_ticks (const struct list_elem *a, const struct list_elem *b,
 		return ta->priority > tb->priority;
 
 	return ta->wakeup_ticks < tb->wakeup_ticks;
+}
+
+// 햇갈릴 수 있는데, 큰게 앞에 위치하도록 조건을 명세의 반대로 한다.
+bool
+cmp_priority(const struct list_elem* a, const struct list_elem* b,
+		void *aux UNUSED) {
+	const struct thread *ta = list_entry (a, struct thread, elem);
+	const struct thread *tb = list_entry (b, struct thread, elem);
+
+	//같은 priority는 false를 반환해서 기존 항목 뒤에 간다.
+	return ta->priority > tb->priority;
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -377,10 +377,20 @@ threads_wakeup (int64_t ticks) {
 void
 thread_set_priority (int new_priority) {
 	struct thread *cur = thread_current ();
+
 	cur->base_priority = new_priority;
-	if (cur->priority < new_priority) {
-		cur->priority = new_priority;
+
+	//donations 확인해서 priority 올바르게 갱신
+	cur->priority = cur->base_priority;
+	if (!list_empty(&cur->donations)) {
+		int max_priority = list_entry (list_min (&cur->donations,
+				cmp_priority, NULL), struct thread, d_elem)->priority;
+
+		if (cur->priority < max_priority) {
+			cur->priority = max_priority;
+		}
 	}
+
 	thread_yield_if_needed();
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -62,7 +62,7 @@ static void kernel_thread (thread_func *, void *aux);
 static void idle (void *aux UNUSED);
 static struct thread *next_thread_to_run (void);
 static void init_thread (struct thread *, const char *name, int priority);
-static void do_schedule(int status);
+static void do_schedule (int status);
 static void schedule (void);
 static tid_t allocate_tid (void);
 static bool cmp_wakeup_ticks (const struct list_elem *a,
@@ -212,7 +212,7 @@ thread_create (const char *name, int priority,
 
 	/* 실행 대기열에 추가합니다. */
 	thread_unblock (t);
-	thread_yield_if_needed();
+	thread_yield_if_needed ();
 
 	return tid;
 }
@@ -321,7 +321,7 @@ thread_yield_if_needed (void) {
 	if (list_empty (&ready_list))
 		return;
 
-	list_sort(&ready_list, cmp_priority, NULL); // Priority Donation 떄문
+	list_sort (&ready_list, cmp_priority, NULL); // Priority Donation 때문
 	struct thread *peek_t =
 		list_entry (list_front (&ready_list), struct thread, elem);
 	bool need_preemption = peek_t->priority > thread_current ()->priority;
@@ -370,7 +370,7 @@ threads_wakeup (int64_t ticks) {
 			break;
 		}
 	}
-	thread_yield_if_needed();
+	thread_yield_if_needed ();
 }
 
 /* 현재 스레드의 우선순위를 NEW_PRIORITY 으로 설정합니다. */
@@ -380,9 +380,9 @@ thread_set_priority (int new_priority) {
 
 	cur->base_priority = new_priority;
 
-	//donations 확인해서 priority 올바르게 갱신
+	/* donations 확인해서 priority 올바르게 갱신한다. */
 	cur->priority = cur->base_priority;
-	if (!list_empty(&cur->donations)) {
+	if (!list_empty (&cur->donations)) {
 		int max_priority = list_entry (list_min (&cur->donations,
 				cmp_priority, NULL), struct thread, d_elem)->priority;
 
@@ -391,7 +391,7 @@ thread_set_priority (int new_priority) {
 		}
 	}
 
-	thread_yield_if_needed();
+	thread_yield_if_needed ();
 }
 
 /* 현재 스레드의 우선순위를 반환합니다. */
@@ -491,7 +491,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->base_priority = priority;
 	t->magic = THREAD_MAGIC;
 	t->wait_on_lock = NULL;
-	list_init(&t->donations);
+	list_init (&t->donations);
 }
 
 /* 예약할 다음 스레드를 선택하고 반환합니다. 해야 한다
@@ -503,7 +503,7 @@ static struct thread *
 next_thread_to_run (void) {
 	if (list_empty (&ready_list))
 		return idle_thread;
-	list_sort(&ready_list, cmp_priority, NULL); // Priority Donation 때매 정렬 필요
+	list_sort (&ready_list, cmp_priority, NULL); // Priority Donation 때문에 정렬 필요
 	return list_entry (list_pop_front (&ready_list), struct thread, elem);
 }
 
@@ -609,13 +609,13 @@ thread_launch (struct thread *th) {
  * 실행할 다른 스레드를 찾아 해당 스레드로 전환합니다.
  * schedule()에서 printf()을 호출하는 것은 안전하지 않습니다. */
 static void
-do_schedule(int status) {
+do_schedule (int status) {
 	ASSERT (intr_get_level () == INTR_OFF);
-	ASSERT (thread_current()->status == THREAD_RUNNING);
+	ASSERT (thread_current ()->status == THREAD_RUNNING);
 	while (!list_empty (&destruction_req)) {
 		struct thread *victim =
 			list_entry (list_pop_front (&destruction_req), struct thread, elem);
-		palloc_free_page(victim);
+		palloc_free_page (victim);
 	}
 	thread_current ()->status = status;
 	schedule ();
@@ -684,13 +684,13 @@ cmp_wakeup_ticks (const struct list_elem *a, const struct list_elem *b,
 	return ta->wakeup_ticks < tb->wakeup_ticks;
 }
 
-// 햇갈릴 수 있는데, 큰게 앞에 위치하도록 조건을 명세의 반대로 한다.
+/* 헷갈릴 수 있는데, 큰 게 앞에 위치하도록 조건을 명세의 반대로 한다. */
 bool
-cmp_priority(const struct list_elem* a, const struct list_elem* b,
+cmp_priority (const struct list_elem *a, const struct list_elem *b,
 		void *aux UNUSED) {
 	const struct thread *ta = list_entry (a, struct thread, elem);
 	const struct thread *tb = list_entry (b, struct thread, elem);
 
-	//같은 priority는 false를 반환해서 기존 항목 뒤에 간다.
+	/* 같은 priority는 false를 반환해서 기존 항목 뒤에 간다. */
 	return ta->priority > tb->priority;
 }


### PR DESCRIPTION
정글에서 공식적으로 제공하지 않는 Clion IDE를 사용하여, 별도 개발 환경을 사용합니다.    
기존 내역에서 코드 수정 사항만 AI를 활용해 옮겨서 PR을 제출하였습니다. 

### 구현

- **Alarm Clock**: sleep_list는 thread의 `wait_ticks` 정렬 상태를 유지합니다.
- **Priority Scheduling**: 
  - 우선순위 높은 순으로 정렬 상태를 유지: `ready_list`,  semaphore의 `waiters`
  - `lock`(Mutex)의 Priority Dontain 기능을 구현합니다. 
  - 선점형 스케줄링을 위해, 우선순위가 변경되고, 더 높은 우선순위가 존재하는 경우 즉시 yield합니다.
  
### 통과하는 테스트

- `priority-donate-one`
- `priority-donate-multiple`
- `priority-donate-multiple2`
- `priority-donate-nest`
- `priority-donate-sema`
- `priority-donate-lower`
- `priority-donate-chain`
- `alarm-priority`
- `priority-preempt`
- `priority-change`
- `priority-fifo`
- `priority-sema`
- `priority-condvar`


### 현재 문제점
~~Priority Scheduling을 구현하면서 `priority-change`, `priority-fifo`가 실패하고 있습니다.  
확인하고 수정 중에 있습니다.~~

(2026-04-28 04:35) 해결 완료