### PR TITLE
docs: userprog 주석 한국어 번역

### DIFF
--- a/pintos/include/userprog/exception.h
+++ b/pintos/include/userprog/exception.h
@@ -1,10 +1,10 @@
 #ifndef USERPROG_EXCEPTION_H
 #define USERPROG_EXCEPTION_H
 
-/* Page fault error code bits that describe the cause of the exception.  */
-#define PF_P 0x1    /* 0: not-present page. 1: access rights violation. */
-#define PF_W 0x2    /* 0: read, 1: write. */
-#define PF_U 0x4    /* 0: kernel, 1: user process. */
+/* 예외의 원인을 나타내는 페이지 폴트 오류 코드 비트. */
+#define PF_P 0x1    /* 0: 존재하지 않는 페이지. 1: 접근 권한 위반. */
+#define PF_W 0x2    /* 0: 읽기, 1: 쓰기. */
+#define PF_U 0x4    /* 0: 커널, 1: 사용자 프로세스. */
 
 void exception_init (void);
 void exception_print_stats (void);

--- a/pintos/userprog/Make.vars
+++ b/pintos/userprog/Make.vars
@@ -6,7 +6,7 @@ KERNEL_SUBDIRS += devices lib lib/kernel userprog filesys
 TEST_SUBDIRS = tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads
 GRADING_FILE = $(SRCDIR)/tests/userprog/Grading.no-extra
 
-# Uncomment the lines below to submit/test extra for project 2.
+# 프로젝트 2 추가 과제를 제출/테스트하려면 아래 줄의 주석을 해제한다.
 # TDEFINE := -DEXTRA2
 # TEST_SUBDIRS += tests/userprog/dup2
 # GRADING_FILE = $(SRCDIR)/tests/userprog/Grading.extra

--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -6,42 +6,37 @@
 #include "threads/thread.h"
 #include "intrinsic.h"
 
-/* Number of page faults processed. */
+/* 처리한 페이지 폴트 수. */
 static long long page_fault_cnt;
 
 static void kill (struct intr_frame *);
 static void page_fault (struct intr_frame *);
 
-/* Registers handlers for interrupts that can be caused by user
-   programs.
+/* 사용자 프로그램이 일으킬 수 있는 인터럽트의 핸들러를 등록한다.
 
-   In a real Unix-like OS, most of these interrupts would be
-   passed along to the user process in the form of signals, as
-   described in [SV-386] 3-24 and 3-25, but we don't implement
-   signals.  Instead, we'll make them simply kill the user
-   process.
+   실제 Unix 계열 OS에서는 [SV-386] 3-24 및 3-25에 설명된 것처럼
+   이러한 인터럽트 대부분을 시그널 형태로 사용자 프로세스에 전달하지만,
+   우리는 시그널을 구현하지 않는다. 대신 단순히 사용자 프로세스를
+   종료하도록 만든다.
 
-   Page faults are an exception.  Here they are treated the same
-   way as other exceptions, but this will need to change to
-   implement virtual memory.
+   페이지 폴트는 예외다. 여기서는 다른 예외와 같은 방식으로 처리하지만,
+   가상 메모리를 구현하려면 이 동작을 바꿔야 한다.
 
-   Refer to [IA32-v3a] section 5.15 "Exception and Interrupt
-   Reference" for a description of each of these exceptions. */
+   각 예외에 대한 설명은 [IA32-v3a] 5.15절 "Exception and Interrupt
+   Reference"를 참고하라. */
 void
 exception_init (void) {
-	/* These exceptions can be raised explicitly by a user program,
-	   e.g. via the INT, INT3, INTO, and BOUND instructions.  Thus,
-	   we set DPL==3, meaning that user programs are allowed to
-	   invoke them via these instructions. */
+	/* 이 예외들은 사용자 프로그램이 INT, INT3, INTO, BOUND 명령어 등을
+	   통해 명시적으로 발생시킬 수 있다. 따라서 DPL==3으로 설정하여
+	   사용자 프로그램이 이러한 명령어로 예외를 호출할 수 있게 한다. */
 	intr_register_int (3, 3, INTR_ON, kill, "#BP Breakpoint Exception");
 	intr_register_int (4, 3, INTR_ON, kill, "#OF Overflow Exception");
 	intr_register_int (5, 3, INTR_ON, kill,
 			"#BR BOUND Range Exceeded Exception");
 
-	/* These exceptions have DPL==0, preventing user processes from
-	   invoking them via the INT instruction.  They can still be
-	   caused indirectly, e.g. #DE can be caused by dividing by
-	   0.  */
+	/* 이 예외들은 DPL==0이므로 사용자 프로세스가 INT 명령어로 호출할 수
+	   없다. 그래도 간접적으로는 발생할 수 있다. 예를 들어 #DE는 0으로
+	   나누면 발생할 수 있다. */
 	intr_register_int (0, 0, INTR_ON, kill, "#DE Divide Error");
 	intr_register_int (1, 0, INTR_ON, kill, "#DB Debug Exception");
 	intr_register_int (6, 0, INTR_ON, kill, "#UD Invalid Opcode Exception");
@@ -54,102 +49,97 @@ exception_init (void) {
 	intr_register_int (19, 0, INTR_ON, kill,
 			"#XF SIMD Floating-Point Exception");
 
-	/* Most exceptions can be handled with interrupts turned on.
-	   We need to disable interrupts for page faults because the
-	   fault address is stored in CR2 and needs to be preserved. */
+	/* 대부분의 예외는 인터럽트를 켠 상태에서 처리할 수 있다. 페이지 폴트는
+	   폴트 주소가 CR2에 저장되며 이를 보존해야 하므로 인터럽트를 꺼야 한다. */
 	intr_register_int (14, 0, INTR_OFF, page_fault, "#PF Page-Fault Exception");
 }
 
-/* Prints exception statistics. */
+/* 예외 통계를 출력한다. */
 void
 exception_print_stats (void) {
 	printf ("Exception: %lld page faults\n", page_fault_cnt);
 }
 
-/* Handler for an exception (probably) caused by a user process. */
+/* 사용자 프로세스가 일으켰을 가능성이 높은 예외를 처리하는 핸들러. */
 static void
 kill (struct intr_frame *f) {
-	/* This interrupt is one (probably) caused by a user process.
-	   For example, the process might have tried to access unmapped
-	   virtual memory (a page fault).  For now, we simply kill the
-	   user process.  Later, we'll want to handle page faults in
-	   the kernel.  Real Unix-like operating systems pass most
-	   exceptions back to the process via signals, but we don't
-	   implement them. */
+	/* 이 인터럽트는 사용자 프로세스가 일으켰을 가능성이 높다. 예를 들어,
+	   프로세스가 매핑되지 않은 가상 메모리에 접근하려 했을 수 있다
+	   (페이지 폴트). 지금은 단순히 사용자 프로세스를 종료한다. 나중에는
+	   페이지 폴트를 커널에서 처리해야 한다. 실제 Unix 계열 운영체제는
+	   대부분의 예외를 시그널을 통해 프로세스에 돌려보내지만, 우리는
+	   시그널을 구현하지 않는다. */
 
-	/* The interrupt frame's code segment value tells us where the
-	   exception originated. */
+	/* 인터럽트 프레임의 코드 세그먼트 값은 예외가 어디에서 발생했는지
+	   알려준다. */
 	switch (f->cs) {
 		case SEL_UCSEG:
-			/* User's code segment, so it's a user exception, as we
-			   expected.  Kill the user process.  */
+			/* 사용자 코드 세그먼트이므로 예상대로 사용자 예외다.
+			   사용자 프로세스를 종료한다. */
 			printf ("%s: dying due to interrupt %#04llx (%s).\n",
 					thread_name (), f->vec_no, intr_name (f->vec_no));
 			intr_dump_frame (f);
 			thread_exit ();
 
 		case SEL_KCSEG:
-			/* Kernel's code segment, which indicates a kernel bug.
-			   Kernel code shouldn't throw exceptions.  (Page faults
-			   may cause kernel exceptions--but they shouldn't arrive
-			   here.)  Panic the kernel to make the point.  */
+			/* 커널 코드 세그먼트이므로 커널 버그를 의미한다. 커널 코드는
+			   예외를 던지면 안 된다. (페이지 폴트가 커널 예외를 일으킬 수는
+			   있지만 여기로 도착해서는 안 된다.) 이 점을 분명히 하기 위해
+			   커널 패닉을 발생시킨다. */
 			intr_dump_frame (f);
 			PANIC ("Kernel bug - unexpected interrupt in kernel");
 
 		default:
-			/* Some other code segment?  Shouldn't happen.  Panic the
-			   kernel. */
+			/* 다른 코드 세그먼트인가? 발생해서는 안 된다. 커널 패닉을
+			   발생시킨다. */
 			printf ("Interrupt %#04llx (%s) in unknown segment %04x\n",
 					f->vec_no, intr_name (f->vec_no), f->cs);
 			thread_exit ();
 	}
 }
 
-/* Page fault handler.  This is a skeleton that must be filled in
-   to implement virtual memory.  Some solutions to project 2 may
-   also require modifying this code.
+/* 페이지 폴트 핸들러. 가상 메모리를 구현하려면 채워 넣어야 하는 골격이다.
+   프로젝트 2의 일부 풀이에서도 이 코드를 수정해야 할 수 있다.
 
-   At entry, the address that faulted is in CR2 (Control Register
-   2) and information about the fault, formatted as described in
-   the PF_* macros in exception.h, is in F's error_code member.  The
-   example code here shows how to parse that information.  You
-   can find more information about both of these in the
-   description of "Interrupt 14--Page Fault Exception (#PF)" in
-   [IA32-v3a] section 5.15 "Exception and Interrupt Reference". */
+   진입 시 폴트를 일으킨 주소는 CR2(Control Register 2)에 들어 있고,
+   폴트에 대한 정보는 exception.h의 PF_* 매크로에 설명된 형식으로
+   F의 error_code 멤버에 들어 있다. 여기의 예제 코드는 그 정보를
+   파싱하는 방법을 보여준다. 두 정보에 대한 자세한 내용은 [IA32-v3a]
+   5.15절 "Exception and Interrupt Reference"의 "Interrupt 14--Page
+   Fault Exception (#PF)" 설명에서 찾을 수 있다. */
 static void
 page_fault (struct intr_frame *f) {
-	bool not_present;  /* True: not-present page, false: writing r/o page. */
-	bool write;        /* True: access was write, false: access was read. */
-	bool user;         /* True: access by user, false: access by kernel. */
-	void *fault_addr;  /* Fault address. */
+	bool not_present;  /* 참: 존재하지 않는 페이지, 거짓: 읽기 전용 페이지에 쓰기. */
+	bool write;        /* 참: 쓰기 접근, 거짓: 읽기 접근. */
+	bool user;         /* 참: 사용자 접근, 거짓: 커널 접근. */
+	void *fault_addr;  /* 폴트 주소. */
 
-	/* Obtain faulting address, the virtual address that was
-	   accessed to cause the fault.  It may point to code or to
-	   data.  It is not necessarily the address of the instruction
-	   that caused the fault (that's f->rip). */
+	/* 폴트를 일으킨 주소, 즉 폴트를 발생시킨 접근 대상 가상 주소를 얻는다.
+	   이 주소는 코드나 데이터를 가리킬 수 있다. 반드시 폴트를 일으킨
+	   명령어의 주소는 아니다(그 주소는 f->rip이다). */
 
 	fault_addr = (void *) rcr2();
 
-	/* Turn interrupts back on (they were only off so that we could
-	   be assured of reading CR2 before it changed). */
+	/* 인터럽트를 다시 켠다. 인터럽트를 껐던 이유는 CR2가 바뀌기 전에
+	   확실히 읽기 위해서뿐이다. */
 	intr_enable ();
 
 
-	/* Determine cause. */
+	/* 원인을 판별한다. */
 	not_present = (f->error_code & PF_P) == 0;
 	write = (f->error_code & PF_W) != 0;
 	user = (f->error_code & PF_U) != 0;
 
 #ifdef VM
-	/* For project 3 and later. */
+	/* 프로젝트 3 이후에서 사용한다. */
 	if (vm_try_handle_fault (f, fault_addr, user, write, not_present))
 		return;
 #endif
 
-	/* Count page faults. */
+	/* 페이지 폴트를 집계한다. */
 	page_fault_cnt++;
 
-	/* If the fault is true fault, show info and exit. */
+	/* 실제 폴트라면 정보를 보여주고 종료한다. */
 	printf ("Page fault at %p: %s error %s page in %s context.\n",
 			fault_addr,
 			not_present ? "not present" : "rights violation",
@@ -157,4 +147,3 @@ page_fault (struct intr_frame *f) {
 			user ? "user" : "kernel");
 	kill (f);
 }
-

--- a/pintos/userprog/gdt.c
+++ b/pintos/userprog/gdt.c
@@ -6,20 +6,16 @@
 #include "threads/vaddr.h"
 #include "intrinsic.h"
 
-/* The Global Descriptor Table (GDT).
+/* 전역 디스크립터 테이블(GDT).
  *
- * The GDT, an x86-64 specific structure, defines segments that can
- * potentially be used by all processes in a system, subject to
- * their permissions.  There is also a per-process Local
- * Descriptor Table (LDT) but that is not used by modern
- * operating systems.
+ * GDT는 x86-64 전용 구조체로, 권한에 따라 시스템의 모든 프로세스가
+ * 사용할 수 있는 세그먼트를 정의한다. 프로세스별 지역 디스크립터
+ * 테이블(LDT)도 있지만 현대 운영체제에서는 사용하지 않는다.
  *
- * Each entry in the GDT, which is known by its byte offset in
- * the table, identifies a segment.  For our purposes only three
- * types of segments are of interest: code, data, and TSS or
- * Task-State Segment descriptors.  The former two types are
- * exactly what they sound like.  The TSS is used primarily for
- * stack switching on interrupts. */
+ * GDT의 각 엔트리는 테이블 안에서의 바이트 오프셋으로 식별되며, 하나의
+ * 세그먼트를 나타낸다. 여기서 관심 있는 세그먼트 종류는 코드, 데이터,
+ * TSS(태스크 상태 세그먼트) 디스크립터 세 가지뿐이다. 앞의 두 종류는
+ * 이름 그대로의 의미이고, TSS는 주로 인터럽트 시 스택 전환에 사용된다. */
 
 struct segment_desc {
 	unsigned lim_15_0 : 16;
@@ -77,11 +73,11 @@ struct desc_ptr gdt_ds = {
 	.address = (uint64_t) gdt
 };
 
-/* Sets up a proper GDT.  The bootstrap loader's GDT didn't
-   include user-mode selectors or a TSS, but we need both now. */
+/* 올바른 GDT를 설정한다. 부트스트랩 로더의 GDT에는 사용자 모드 셀렉터나
+   TSS가 없었지만, 이제는 둘 다 필요하다. */
 void
 gdt_init (void) {
-	/* Initialize GDT. */
+	/* GDT를 초기화한다. */
 	struct segment_descriptor64 *tss_desc =
 		(struct segment_descriptor64 *) &gdt[SEL_TSS >> 3];
 	struct task_state *tss = tss_get ();
@@ -106,7 +102,7 @@ gdt_init (void) {
 	};
 
 	lgdt (&gdt_ds);
-	/* reload segment registers */
+	/* 세그먼트 레지스터를 다시 로드한다. */
 	asm volatile("movw %%ax, %%gs" :: "a" (SEL_UDSEG));
 	asm volatile("movw %%ax, %%fs" :: "a" (0));
 	asm volatile("movw %%ax, %%es" :: "a" (SEL_KDSEG));
@@ -117,6 +113,6 @@ gdt_init (void) {
 			"pushq %%rax\n"
 			"lretq\n"
 			"1:\n" :: "b" (SEL_KCSEG):"cc","memory");
-	/* Kill the local descriptor table */
+	/* 로컬 디스크립터 테이블을 비활성화한다. */
 	lldt (0);
 }

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -27,37 +27,36 @@ static bool load (const char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
 
-/* General process initializer for initd and other process. */
+/* initd와 다른 프로세스를 위한 일반 프로세스 초기화 함수. */
 static void
 process_init (void) {
 	struct thread *current = thread_current ();
 }
 
-/* Starts the first userland program, called "initd", loaded from FILE_NAME.
- * The new thread may be scheduled (and may even exit)
- * before process_create_initd() returns. Returns the initd's
- * thread id, or TID_ERROR if the thread cannot be created.
- * Notice that THIS SHOULD BE CALLED ONCE. */
+/* FILE_NAME에서 로드되는 첫 사용자 영역 프로그램인 "initd"를 시작한다.
+ * 새 스레드는 process_create_initd()가 반환되기 전에 스케줄될 수 있고,
+ * 심지어 종료될 수도 있다. initd의 스레드 id를 반환하며, 스레드를 만들 수
+ * 없으면 TID_ERROR를 반환한다. 이 함수는 반드시 한 번만 호출되어야 한다. */
 tid_t
 process_create_initd (const char *file_name) {
 	char *fn_copy;
 	tid_t tid;
 
-	/* Make a copy of FILE_NAME.
-	 * Otherwise there's a race between the caller and load(). */
+	/* FILE_NAME의 복사본을 만든다.
+	 * 그렇지 않으면 호출자와 load() 사이에 경쟁 상태가 생긴다. */
 	fn_copy = palloc_get_page (0);
 	if (fn_copy == NULL)
 		return TID_ERROR;
 	strlcpy (fn_copy, file_name, PGSIZE);
 
-	/* Create a new thread to execute FILE_NAME. */
+	/* FILE_NAME을 실행할 새 스레드를 만든다. */
 	tid = thread_create (file_name, PRI_DEFAULT, initd, fn_copy);
 	if (tid == TID_ERROR)
 		palloc_free_page (fn_copy);
 	return tid;
 }
 
-/* A thread function that launches first user process. */
+/* 첫 사용자 프로세스를 시작하는 스레드 함수. */
 static void
 initd (void *f_name) {
 #ifdef VM
@@ -71,18 +70,18 @@ initd (void *f_name) {
 	NOT_REACHED ();
 }
 
-/* Clones the current process as `name`. Returns the new process's thread id, or
- * TID_ERROR if the thread cannot be created. */
+/* 현재 프로세스를 `name`으로 복제한다. 새 프로세스의 스레드 id를 반환하며,
+ * 스레드를 만들 수 없으면 TID_ERROR를 반환한다. */
 tid_t
 process_fork (const char *name, struct intr_frame *if_ UNUSED) {
-	/* Clone current thread to new thread.*/
+	/* 현재 스레드를 새 스레드로 복제한다. */
 	return thread_create (name,
 			PRI_DEFAULT, __do_fork, thread_current ());
 }
 
 #ifndef VM
-/* Duplicate the parent's address space by passing this function to the
- * pml4_for_each. This is only for the project 2. */
+/* 이 함수를 pml4_for_each에 전달하여 부모의 주소 공간을 복제한다.
+ * 이 코드는 프로젝트 2에서만 사용한다. */
 static bool
 duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	struct thread *current = thread_current ();
@@ -91,44 +90,42 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	void *newpage;
 	bool writable;
 
-	/* 1. TODO: If the parent_page is kernel page, then return immediately. */
+	/* 1. TODO: parent_page가 커널 페이지라면 즉시 반환한다. */
 
-	/* 2. Resolve VA from the parent's page map level 4. */
+	/* 2. 부모의 페이지 맵 레벨 4에서 VA를 해석한다. */
 	parent_page = pml4_get_page (parent->pml4, va);
 
-	/* 3. TODO: Allocate new PAL_USER page for the child and set result to
-	 *    TODO: NEWPAGE. */
+	/* 3. TODO: 자식을 위한 새 PAL_USER 페이지를 할당하고 결과를
+	 *    TODO: NEWPAGE에 설정한다. */
 
-	/* 4. TODO: Duplicate parent's page to the new page and
-	 *    TODO: check whether parent's page is writable or not (set WRITABLE
-	 *    TODO: according to the result). */
+	/* 4. TODO: 부모의 페이지를 새 페이지로 복제하고, 부모 페이지가 쓰기
+	 *    TODO: 가능한지 확인한다(결과에 따라 WRITABLE을 설정한다). */
 
-	/* 5. Add new page to child's page table at address VA with WRITABLE
-	 *    permission. */
+	/* 5. 새 페이지를 자식의 페이지 테이블에 VA 주소와 WRITABLE 권한으로
+	 *    추가한다. */
 	if (!pml4_set_page (current->pml4, va, newpage, writable)) {
-		/* 6. TODO: if fail to insert page, do error handling. */
+		/* 6. TODO: 페이지 삽입에 실패하면 오류 처리를 수행한다. */
 	}
 	return true;
 }
 #endif
 
-/* A thread function that copies parent's execution context.
- * Hint) parent->tf does not hold the userland context of the process.
- *       That is, you are required to pass second argument of process_fork to
- *       this function. */
+/* 부모의 실행 컨텍스트를 복사하는 스레드 함수.
+ * 힌트) parent->tf는 프로세스의 사용자 영역 컨텍스트를 보관하지 않는다.
+ *       즉, process_fork의 두 번째 인자를 이 함수에 전달해야 한다. */
 static void
 __do_fork (void *aux) {
 	struct intr_frame if_;
 	struct thread *parent = (struct thread *) aux;
 	struct thread *current = thread_current ();
-	/* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
+	/* TODO: 어떤 방식으로든 parent_if를 전달한다. (즉, process_fork()의 if_) */
 	struct intr_frame *parent_if;
 	bool succ = true;
 
-	/* 1. Read the cpu context to local stack. */
+	/* 1. CPU 컨텍스트를 로컬 스택으로 읽는다. */
 	memcpy (&if_, parent_if, sizeof (struct intr_frame));
 
-	/* 2. Duplicate PT */
+	/* 2. 페이지 테이블을 복제한다. */
 	current->pml4 = pml4_create();
 	if (current->pml4 == NULL)
 		goto error;
@@ -143,83 +140,79 @@ __do_fork (void *aux) {
 		goto error;
 #endif
 
-	/* TODO: Your code goes here.
-	 * TODO: Hint) To duplicate the file object, use `file_duplicate`
-	 * TODO:       in include/filesys/file.h. Note that parent should not return
-	 * TODO:       from the fork() until this function successfully duplicates
-	 * TODO:       the resources of parent.*/
+	/* TODO: 구현 내용을 여기에 작성한다.
+	 * TODO: 힌트) 파일 객체를 복제하려면 include/filesys/file.h의
+	 * TODO:       `file_duplicate`를 사용한다. 이 함수가 부모의 리소스를
+	 * TODO:       성공적으로 복제하기 전까지 부모는 fork()에서 반환하면
+	 * TODO:       안 된다는 점에 유의하라. */
 
 	process_init ();
 
-	/* Finally, switch to the newly created process. */
+	/* 마지막으로 새로 생성한 프로세스로 전환한다. */
 	if (succ)
 		do_iret (&if_);
 error:
 	thread_exit ();
 }
 
-/* Switch the current execution context to the f_name.
- * Returns -1 on fail. */
+/* 현재 실행 컨텍스트를 f_name으로 전환한다.
+ * 실패하면 -1을 반환한다. */
 int
 process_exec (void *f_name) {
 	char *file_name = f_name;
 	bool success;
 
-	/* We cannot use the intr_frame in the thread structure.
-	 * This is because when current thread rescheduled,
-	 * it stores the execution information to the member. */
+	/* thread 구조체 안의 intr_frame은 사용할 수 없다.
+	 * 현재 스레드가 다시 스케줄될 때 실행 정보를 그 멤버에 저장하기 때문이다. */
 	struct intr_frame _if;
 	_if.ds = _if.es = _if.ss = SEL_UDSEG;
 	_if.cs = SEL_UCSEG;
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
-	/* We first kill the current context */
+	/* 먼저 현재 컨텍스트를 제거한다. */
 	process_cleanup ();
 
-	/* And then load the binary */
+	/* 그런 다음 바이너리를 로드한다. */
 	success = load (file_name, &_if);
 
-	/* If load failed, quit. */
+	/* load에 실패했으면 종료한다. */
 	palloc_free_page (file_name);
 	if (!success)
 		return -1;
 
-	/* Start switched process. */
+	/* 전환된 프로세스를 시작한다. */
 	do_iret (&_if);
 	NOT_REACHED ();
 }
 
 
-/* Waits for thread TID to die and returns its exit status.  If
- * it was terminated by the kernel (i.e. killed due to an
- * exception), returns -1.  If TID is invalid or if it was not a
- * child of the calling process, or if process_wait() has already
- * been successfully called for the given TID, returns -1
- * immediately, without waiting.
+/* 스레드 TID가 종료될 때까지 기다린 뒤 종료 상태를 반환한다. 커널에 의해
+ * 종료되었다면(즉, 예외 때문에 종료되었다면) -1을 반환한다. TID가
+ * 유효하지 않거나, 호출 프로세스의 자식이 아니거나, 주어진 TID에 대해
+ * process_wait()가 이미 성공적으로 호출된 적이 있다면 기다리지 않고 즉시
+ * -1을 반환한다.
  *
- * This function will be implemented in problem 2-2.  For now, it
- * does nothing. */
+ * 이 함수는 문제 2-2에서 구현된다. 지금은 아무 일도 하지 않는다. */
 int
 process_wait (tid_t child_tid UNUSED) {
-	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
-	 * XXX:       to add infinite loop here before
-	 * XXX:       implementing the process_wait. */
+	/* XXX: 힌트) process_wait(initd)에서 Pintos가 종료된다. process_wait를
+	 * XXX:       구현하기 전에는 여기에 무한 루프를 추가하는 것을 권장한다. */
 	return -1;
 }
 
-/* Exit the process. This function is called by thread_exit (). */
+/* 프로세스를 종료한다. 이 함수는 thread_exit()에서 호출된다. */
 void
 process_exit (void) {
 	struct thread *curr = thread_current ();
-	/* TODO: Your code goes here.
-	 * TODO: Implement process termination message (see
-	 * TODO: project2/process_termination.html).
-	 * TODO: We recommend you to implement process resource cleanup here. */
+	/* TODO: 구현 내용을 여기에 작성한다.
+	 * TODO: 프로세스 종료 메시지를 구현한다
+	 * TODO: (project2/process_termination.html 참고).
+	 * TODO: 여기에서 프로세스 리소스 정리를 구현하는 것을 권장한다. */
 
 	process_cleanup ();
 }
 
-/* Free the current process's resources. */
+/* 현재 프로세스의 리소스를 해제한다. */
 static void
 process_cleanup (void) {
 	struct thread *curr = thread_current ();
@@ -229,55 +222,53 @@ process_cleanup (void) {
 #endif
 
 	uint64_t *pml4;
-	/* Destroy the current process's page directory and switch back
-	 * to the kernel-only page directory. */
+	/* 현재 프로세스의 페이지 디렉터리를 파괴하고 커널 전용 페이지
+	 * 디렉터리로 다시 전환한다. */
 	pml4 = curr->pml4;
 	if (pml4 != NULL) {
-		/* Correct ordering here is crucial.  We must set
-		 * cur->pagedir to NULL before switching page directories,
-		 * so that a timer interrupt can't switch back to the
-		 * process page directory.  We must activate the base page
-		 * directory before destroying the process's page
-		 * directory, or our active page directory will be one
-		 * that's been freed (and cleared). */
+		/* 여기서는 순서가 매우 중요하다. 페이지 디렉터리를 전환하기 전에
+		 * cur->pagedir를 NULL로 설정해야 타이머 인터럽트가 프로세스 페이지
+		 * 디렉터리로 다시 전환하지 못한다. 또한 프로세스의 페이지 디렉터리를
+		 * 파괴하기 전에 기본 페이지 디렉터리를 활성화해야 한다. 그렇지 않으면
+		 * 이미 해제되고 지워진 페이지 디렉터리가 활성 상태가 될 수 있다. */
 		curr->pml4 = NULL;
 		pml4_activate (NULL);
 		pml4_destroy (pml4);
 	}
 }
 
-/* Sets up the CPU for running user code in the nest thread.
- * This function is called on every context switch. */
+/* 다음 스레드에서 사용자 코드를 실행할 수 있도록 CPU를 설정한다.
+ * 이 함수는 문맥 전환 때마다 호출된다. */
 void
 process_activate (struct thread *next) {
-	/* Activate thread's page tables. */
+	/* 스레드의 페이지 테이블을 활성화한다. */
 	pml4_activate (next->pml4);
 
-	/* Set thread's kernel stack for use in processing interrupts. */
+	/* 인터럽트 처리에 사용할 스레드의 커널 스택을 설정한다. */
 	tss_update (next);
 }
 
-/* We load ELF binaries.  The following definitions are taken
- * from the ELF specification, [ELF1], more-or-less verbatim.  */
+/* 우리는 ELF 바이너리를 로드한다. 다음 정의들은 [ELF1]의 ELF 명세에서
+ * 거의 그대로 가져온 것이다. */
 
-/* ELF types.  See [ELF1] 1-2. */
+/* ELF 타입. [ELF1] 1-2를 참고하라. */
 #define EI_NIDENT 16
 
-#define PT_NULL    0            /* Ignore. */
-#define PT_LOAD    1            /* Loadable segment. */
-#define PT_DYNAMIC 2            /* Dynamic linking info. */
-#define PT_INTERP  3            /* Name of dynamic loader. */
-#define PT_NOTE    4            /* Auxiliary info. */
-#define PT_SHLIB   5            /* Reserved. */
-#define PT_PHDR    6            /* Program header table. */
-#define PT_STACK   0x6474e551   /* Stack segment. */
+#define PT_NULL    0            /* 무시. */
+#define PT_LOAD    1            /* 로드 가능한 세그먼트. */
+#define PT_DYNAMIC 2            /* 동적 링킹 정보. */
+#define PT_INTERP  3            /* 동적 로더 이름. */
+#define PT_NOTE    4            /* 보조 정보. */
+#define PT_SHLIB   5            /* 예약됨. */
+#define PT_PHDR    6            /* 프로그램 헤더 테이블. */
+#define PT_STACK   0x6474e551   /* 스택 세그먼트. */
 
-#define PF_X 1          /* Executable. */
-#define PF_W 2          /* Writable. */
-#define PF_R 4          /* Readable. */
+#define PF_X 1          /* 실행 가능. */
+#define PF_W 2          /* 쓰기 가능. */
+#define PF_R 4          /* 읽기 가능. */
 
-/* Executable header.  See [ELF1] 1-4 to 1-8.
- * This appears at the very beginning of an ELF binary. */
+/* 실행 파일 헤더. [ELF1] 1-4부터 1-8까지를 참고하라.
+ * ELF 바이너리의 맨 앞에 위치한다. */
 struct ELF64_hdr {
 	unsigned char e_ident[EI_NIDENT];
 	uint16_t e_type;
@@ -306,7 +297,7 @@ struct ELF64_PHDR {
 	uint64_t p_align;
 };
 
-/* Abbreviations */
+/* 약어. */
 #define ELF ELF64_hdr
 #define Phdr ELF64_PHDR
 
@@ -316,10 +307,9 @@ static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes,
 		bool writable);
 
-/* Loads an ELF executable from FILE_NAME into the current thread.
- * Stores the executable's entry point into *RIP
- * and its initial stack pointer into *RSP.
- * Returns true if successful, false otherwise. */
+/* FILE_NAME의 ELF 실행 파일을 현재 스레드로 로드한다.
+ * 실행 파일의 진입점을 *RIP에 저장하고 초기 스택 포인터를 *RSP에 저장한다.
+ * 성공하면 true, 그렇지 않으면 false를 반환한다. */
 static bool
 load (const char *file_name, struct intr_frame *if_) {
 	struct thread *t = thread_current ();
@@ -329,20 +319,20 @@ load (const char *file_name, struct intr_frame *if_) {
 	bool success = false;
 	int i;
 
-	/* Allocate and activate page directory. */
+	/* 페이지 디렉터리를 할당하고 활성화한다. */
 	t->pml4 = pml4_create ();
 	if (t->pml4 == NULL)
 		goto done;
 	process_activate (thread_current ());
 
-	/* Open executable file. */
+	/* 실행 파일을 연다. */
 	file = filesys_open (file_name);
 	if (file == NULL) {
 		printf ("load: %s: open failed\n", file_name);
 		goto done;
 	}
 
-	/* Read and verify executable header. */
+	/* 실행 파일 헤더를 읽고 검증한다. */
 	if (file_read (file, &ehdr, sizeof ehdr) != sizeof ehdr
 			|| memcmp (ehdr.e_ident, "\177ELF\2\1\1", 7)
 			|| ehdr.e_type != 2
@@ -354,7 +344,7 @@ load (const char *file_name, struct intr_frame *if_) {
 		goto done;
 	}
 
-	/* Read program headers. */
+	/* 프로그램 헤더를 읽는다. */
 	file_ofs = ehdr.e_phoff;
 	for (i = 0; i < ehdr.e_phnum; i++) {
 		struct Phdr phdr;
@@ -372,7 +362,7 @@ load (const char *file_name, struct intr_frame *if_) {
 			case PT_PHDR:
 			case PT_STACK:
 			default:
-				/* Ignore this segment. */
+				/* 이 세그먼트는 무시한다. */
 				break;
 			case PT_DYNAMIC:
 			case PT_INTERP:
@@ -386,14 +376,14 @@ load (const char *file_name, struct intr_frame *if_) {
 					uint64_t page_offset = phdr.p_vaddr & PGMASK;
 					uint32_t read_bytes, zero_bytes;
 					if (phdr.p_filesz > 0) {
-						/* Normal segment.
-						 * Read initial part from disk and zero the rest. */
+						/* 일반 세그먼트.
+						 * 앞부분은 디스크에서 읽고 나머지는 0으로 채운다. */
 						read_bytes = page_offset + phdr.p_filesz;
 						zero_bytes = (ROUND_UP (page_offset + phdr.p_memsz, PGSIZE)
 								- read_bytes);
 					} else {
-						/* Entirely zero.
-						 * Don't read anything from disk. */
+						/* 전체가 0이다.
+						 * 디스크에서 아무것도 읽지 않는다. */
 						read_bytes = 0;
 						zero_bytes = ROUND_UP (page_offset + phdr.p_memsz, PGSIZE);
 					}
@@ -407,91 +397,88 @@ load (const char *file_name, struct intr_frame *if_) {
 		}
 	}
 
-	/* Set up stack. */
+	/* 스택을 설정한다. */
 	if (!setup_stack (if_))
 		goto done;
 
-	/* Start address. */
+	/* 시작 주소. */
 	if_->rip = ehdr.e_entry;
 
-	/* TODO: Your code goes here.
-	 * TODO: Implement argument passing (see project2/argument_passing.html). */
+	/* TODO: 구현 내용을 여기에 작성한다.
+	 * TODO: 인자 전달을 구현한다(project2/argument_passing.html 참고). */
 
 	success = true;
 
 done:
-	/* We arrive here whether the load is successful or not. */
+	/* load 성공 여부와 관계없이 여기로 도착한다. */
 	file_close (file);
 	return success;
 }
 
 
-/* Checks whether PHDR describes a valid, loadable segment in
- * FILE and returns true if so, false otherwise. */
+/* PHDR이 FILE 안의 유효하고 로드 가능한 세그먼트를 설명하는지 확인한다.
+ * 그렇다면 true, 아니면 false를 반환한다. */
 static bool
 validate_segment (const struct Phdr *phdr, struct file *file) {
-	/* p_offset and p_vaddr must have the same page offset. */
+	/* p_offset과 p_vaddr은 같은 페이지 오프셋을 가져야 한다. */
 	if ((phdr->p_offset & PGMASK) != (phdr->p_vaddr & PGMASK))
 		return false;
 
-	/* p_offset must point within FILE. */
+	/* p_offset은 FILE 내부를 가리켜야 한다. */
 	if (phdr->p_offset > (uint64_t) file_length (file))
 		return false;
 
-	/* p_memsz must be at least as big as p_filesz. */
+	/* p_memsz는 적어도 p_filesz만큼 커야 한다. */
 	if (phdr->p_memsz < phdr->p_filesz)
 		return false;
 
-	/* The segment must not be empty. */
+	/* 세그먼트는 비어 있으면 안 된다. */
 	if (phdr->p_memsz == 0)
 		return false;
 
-	/* The virtual memory region must both start and end within the
-	   user address space range. */
+	/* 가상 메모리 영역의 시작과 끝은 모두 사용자 주소 공간 범위 안에
+	   있어야 한다. */
 	if (!is_user_vaddr ((void *) phdr->p_vaddr))
 		return false;
 	if (!is_user_vaddr ((void *) (phdr->p_vaddr + phdr->p_memsz)))
 		return false;
 
-	/* The region cannot "wrap around" across the kernel virtual
-	   address space. */
+	/* 이 영역은 커널 가상 주소 공간을 가로질러 주소가 되감길 수 없다. */
 	if (phdr->p_vaddr + phdr->p_memsz < phdr->p_vaddr)
 		return false;
 
-	/* Disallow mapping page 0.
-	   Not only is it a bad idea to map page 0, but if we allowed
-	   it then user code that passed a null pointer to system calls
-	   could quite likely panic the kernel by way of null pointer
-	   assertions in memcpy(), etc. */
+	/* 페이지 0 매핑을 금지한다.
+	   페이지 0을 매핑하는 것 자체도 좋지 않지만, 이를 허용하면 시스템 콜에
+	   null 포인터를 넘긴 사용자 코드가 memcpy() 등의 null 포인터 assertion을
+	   통해 커널 패닉을 일으킬 가능성이 크다. */
 	if (phdr->p_vaddr < PGSIZE)
 		return false;
 
-	/* It's okay. */
+	/* 문제없다. */
 	return true;
 }
 
 #ifndef VM
-/* Codes of this block will be ONLY USED DURING project 2.
- * If you want to implement the function for whole project 2, implement it
- * outside of #ifndef macro. */
+/* 이 블록의 코드는 프로젝트 2 동안에만 사용된다.
+ * 프로젝트 2 전체에서 이 함수를 구현하고 싶다면 #ifndef 매크로 밖에
+ * 구현하라. */
 
-/* load() helpers. */
+/* load() 보조 함수. */
 static bool install_page (void *upage, void *kpage, bool writable);
 
-/* Loads a segment starting at offset OFS in FILE at address
- * UPAGE.  In total, READ_BYTES + ZERO_BYTES bytes of virtual
- * memory are initialized, as follows:
+/* FILE의 OFS 오프셋에서 시작하는 세그먼트를 UPAGE 주소에 로드한다.
+ * 총 READ_BYTES + ZERO_BYTES 바이트의 가상 메모리를 다음과 같이
+ * 초기화한다.
  *
- * - READ_BYTES bytes at UPAGE must be read from FILE
- * starting at offset OFS.
+ * - UPAGE의 READ_BYTES 바이트는 FILE의 OFS 오프셋부터 읽어야 한다.
  *
- * - ZERO_BYTES bytes at UPAGE + READ_BYTES must be zeroed.
+ * - UPAGE + READ_BYTES의 ZERO_BYTES 바이트는 0으로 채워야 한다.
  *
- * The pages initialized by this function must be writable by the
- * user process if WRITABLE is true, read-only otherwise.
+ * 이 함수가 초기화한 페이지들은 WRITABLE이 true이면 사용자 프로세스가
+ * 쓸 수 있어야 하고, 그렇지 않으면 읽기 전용이어야 한다.
  *
- * Return true if successful, false if a memory allocation error
- * or disk read error occurs. */
+ * 성공하면 true를 반환하고, 메모리 할당 오류나 디스크 읽기 오류가
+ * 발생하면 false를 반환한다. */
 static bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
@@ -501,32 +488,32 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 
 	file_seek (file, ofs);
 	while (read_bytes > 0 || zero_bytes > 0) {
-		/* Do calculate how to fill this page.
-		 * We will read PAGE_READ_BYTES bytes from FILE
-		 * and zero the final PAGE_ZERO_BYTES bytes. */
+		/* 이 페이지를 어떻게 채울지 계산한다.
+		 * FILE에서 PAGE_READ_BYTES 바이트를 읽고 마지막 PAGE_ZERO_BYTES
+		 * 바이트를 0으로 채운다. */
 		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
 		size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-		/* Get a page of memory. */
+		/* 메모리 페이지를 얻는다. */
 		uint8_t *kpage = palloc_get_page (PAL_USER);
 		if (kpage == NULL)
 			return false;
 
-		/* Load this page. */
+		/* 이 페이지를 로드한다. */
 		if (file_read (file, kpage, page_read_bytes) != (int) page_read_bytes) {
 			palloc_free_page (kpage);
 			return false;
 		}
 		memset (kpage + page_read_bytes, 0, page_zero_bytes);
 
-		/* Add the page to the process's address space. */
+		/* 페이지를 프로세스의 주소 공간에 추가한다. */
 		if (!install_page (upage, kpage, writable)) {
 			printf("fail\n");
 			palloc_free_page (kpage);
 			return false;
 		}
 
-		/* Advance. */
+		/* 다음으로 진행한다. */
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
@@ -534,7 +521,7 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 	return true;
 }
 
-/* Create a minimal stack by mapping a zeroed page at the USER_STACK */
+/* USER_STACK에 0으로 채운 페이지를 매핑하여 최소 스택을 만든다. */
 static bool
 setup_stack (struct intr_frame *if_) {
 	uint8_t *kpage;
@@ -551,50 +538,47 @@ setup_stack (struct intr_frame *if_) {
 	return success;
 }
 
-/* Adds a mapping from user virtual address UPAGE to kernel
- * virtual address KPAGE to the page table.
- * If WRITABLE is true, the user process may modify the page;
- * otherwise, it is read-only.
- * UPAGE must not already be mapped.
- * KPAGE should probably be a page obtained from the user pool
- * with palloc_get_page().
- * Returns true on success, false if UPAGE is already mapped or
- * if memory allocation fails. */
+/* 사용자 가상 주소 UPAGE에서 커널 가상 주소 KPAGE로의 매핑을 페이지
+ * 테이블에 추가한다.
+ * WRITABLE이 true이면 사용자 프로세스가 페이지를 수정할 수 있고,
+ * 그렇지 않으면 읽기 전용이다.
+ * UPAGE는 아직 매핑되어 있으면 안 된다.
+ * KPAGE는 palloc_get_page()로 사용자 풀에서 얻은 페이지여야 할 것이다.
+ * 성공하면 true를 반환하고, UPAGE가 이미 매핑되어 있거나 메모리 할당에
+ * 실패하면 false를 반환한다. */
 static bool
 install_page (void *upage, void *kpage, bool writable) {
 	struct thread *t = thread_current ();
 
-	/* Verify that there's not already a page at that virtual
-	 * address, then map our page there. */
+	/* 해당 가상 주소에 이미 페이지가 없는지 확인한 뒤, 그곳에 페이지를
+	 * 매핑한다. */
 	return (pml4_get_page (t->pml4, upage) == NULL
 			&& pml4_set_page (t->pml4, upage, kpage, writable));
 }
 #else
-/* From here, codes will be used after project 3.
- * If you want to implement the function for only project 2, implement it on the
- * upper block. */
+/* 여기부터의 코드는 프로젝트 3 이후에 사용된다.
+ * 프로젝트 2에서만 이 함수를 구현하려면 위쪽 블록에 구현하라. */
 
 static bool
 lazy_load_segment (struct page *page, void *aux) {
-	/* TODO: Load the segment from the file */
-	/* TODO: This called when the first page fault occurs on address VA. */
-	/* TODO: VA is available when calling this function. */
+	/* TODO: 파일에서 세그먼트를 로드한다. */
+	/* TODO: 이 함수는 VA 주소에서 첫 페이지 폴트가 발생했을 때 호출된다. */
+	/* TODO: 이 함수를 호출할 때 VA를 사용할 수 있다. */
 }
 
-/* Loads a segment starting at offset OFS in FILE at address
- * UPAGE.  In total, READ_BYTES + ZERO_BYTES bytes of virtual
- * memory are initialized, as follows:
+/* FILE의 OFS 오프셋에서 시작하는 세그먼트를 UPAGE 주소에 로드한다.
+ * 총 READ_BYTES + ZERO_BYTES 바이트의 가상 메모리를 다음과 같이
+ * 초기화한다.
  *
- * - READ_BYTES bytes at UPAGE must be read from FILE
- * starting at offset OFS.
+ * - UPAGE의 READ_BYTES 바이트는 FILE의 OFS 오프셋부터 읽어야 한다.
  *
- * - ZERO_BYTES bytes at UPAGE + READ_BYTES must be zeroed.
+ * - UPAGE + READ_BYTES의 ZERO_BYTES 바이트는 0으로 채워야 한다.
  *
- * The pages initialized by this function must be writable by the
- * user process if WRITABLE is true, read-only otherwise.
+ * 이 함수가 초기화한 페이지들은 WRITABLE이 true이면 사용자 프로세스가
+ * 쓸 수 있어야 하고, 그렇지 않으면 읽기 전용이어야 한다.
  *
- * Return true if successful, false if a memory allocation error
- * or disk read error occurs. */
+ * 성공하면 true를 반환하고, 메모리 할당 오류나 디스크 읽기 오류가
+ * 발생하면 false를 반환한다. */
 static bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
@@ -603,19 +587,19 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 	ASSERT (ofs % PGSIZE == 0);
 
 	while (read_bytes > 0 || zero_bytes > 0) {
-		/* Do calculate how to fill this page.
-		 * We will read PAGE_READ_BYTES bytes from FILE
-		 * and zero the final PAGE_ZERO_BYTES bytes. */
+		/* 이 페이지를 어떻게 채울지 계산한다.
+		 * FILE에서 PAGE_READ_BYTES 바이트를 읽고 마지막 PAGE_ZERO_BYTES
+		 * 바이트를 0으로 채운다. */
 		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
 		size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-		/* TODO: Set up aux to pass information to the lazy_load_segment. */
+		/* TODO: lazy_load_segment에 정보를 전달하도록 aux를 설정한다. */
 		void *aux = NULL;
 		if (!vm_alloc_page_with_initializer (VM_ANON, upage,
 					writable, lazy_load_segment, aux))
 			return false;
 
-		/* Advance. */
+		/* 다음으로 진행한다. */
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
@@ -623,16 +607,16 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 	return true;
 }
 
-/* Create a PAGE of stack at the USER_STACK. Return true on success. */
+/* USER_STACK에 스택 PAGE를 만든다. 성공하면 true를 반환한다. */
 static bool
 setup_stack (struct intr_frame *if_) {
 	bool success = false;
 	void *stack_bottom = (void *) (((uint8_t *) USER_STACK) - PGSIZE);
 
-	/* TODO: Map the stack on stack_bottom and claim the page immediately.
-	 * TODO: If success, set the rsp accordingly.
-	 * TODO: You should mark the page is stack. */
-	/* TODO: Your code goes here */
+	/* TODO: stack_bottom에 스택을 매핑하고 즉시 페이지를 claim한다.
+	 * TODO: 성공하면 그에 맞게 rsp를 설정한다.
+	 * TODO: 해당 페이지가 스택임을 표시해야 한다. */
+	/* TODO: 구현 내용을 여기에 작성한다. */
 
 	return success;
 }

--- a/pintos/userprog/syscall-entry.S
+++ b/pintos/userprog/syscall-entry.S
@@ -5,18 +5,18 @@
 .type syscall_entry, @function
 syscall_entry:
 	movq %rbx, temp1(%rip)
-	movq %r12, temp2(%rip)     /* callee saved registers */
-	movq %rsp, %rbx            /* Store userland rsp    */
+	movq %r12, temp2(%rip)     /* 피호출자 보존 레지스터 */
+	movq %rsp, %rbx            /* 사용자 영역 rsp 저장 */
 	movabs $tss, %r12
 	movq (%r12), %r12
-	movq 4(%r12), %rsp         /* Read ring0 rsp from the tss */
-	/* Now we are in the kernel stack */
+	movq 4(%r12), %rsp         /* TSS에서 ring0 rsp 읽기 */
+	/* 이제 커널 스택에 있다. */
 	push $(SEL_UDSEG)      /* if->ss */
 	push %rbx              /* if->rsp */
 	push %r11              /* if->eflags */
 	push $(SEL_UCSEG)      /* if->cs */
 	push %rcx              /* if->rip */
-	subq $16, %rsp         /* skip error_code, vec_no */
+	subq $16, %rsp         /* error_code, vec_no 건너뛰기 */
 	push $(SEL_UDSEG)      /* if->ds */
 	push $(SEL_UDSEG)      /* if->es */
 	push %rax
@@ -30,7 +30,7 @@ syscall_entry:
 	push %r8
 	push %r9
 	push %r10
-	pushq $0 /* skip r11 */
+	pushq $0 /* r11 건너뛰기 */
 	movq temp2(%rip), %r12
 	push %r12
 	push %r13
@@ -39,9 +39,9 @@ syscall_entry:
 	movq %rsp, %rdi
 
 check_intr:
-	btsq $9, %r11          /* Check whether we recover the interrupt */
+	btsq $9, %r11          /* 인터럽트를 복구할지 확인 */
 	jnb no_sti
-	sti                    /* restore interrupt */
+	sti                    /* 인터럽트 복구 */
 no_sti:
 	movabs $syscall_handler, %r12
 	call *%r12

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -11,18 +11,18 @@
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 
-/* System call.
+/* 시스템 콜.
  *
- * Previously system call services was handled by the interrupt handler
- * (e.g. int 0x80 in linux). However, in x86-64, the manufacturer supplies
- * efficient path for requesting the system call, the `syscall` instruction.
+ * 이전에는 시스템 콜 서비스가 인터럽트 핸들러를 통해 처리되었다
+ * (예: Linux의 int 0x80). 하지만 x86-64에서는 제조사가 시스템 콜을
+ * 요청하는 효율적인 경로인 `syscall` 명령어를 제공한다.
  *
- * The syscall instruction works by reading the values from the the Model
- * Specific Register (MSR). For the details, see the manual. */
+ * syscall 명령어는 모델별 레지스터(MSR)에서 값을 읽어 동작한다.
+ * 자세한 내용은 매뉴얼을 참고하라. */
 
-#define MSR_STAR 0xc0000081         /* Segment selector msr */
-#define MSR_LSTAR 0xc0000082        /* Long mode SYSCALL target */
-#define MSR_SYSCALL_MASK 0xc0000084 /* Mask for the eflags */
+#define MSR_STAR 0xc0000081         /* 세그먼트 셀렉터 MSR. */
+#define MSR_LSTAR 0xc0000082        /* 롱 모드 SYSCALL 대상. */
+#define MSR_SYSCALL_MASK 0xc0000084 /* eflags용 마스크. */
 
 void
 syscall_init (void) {
@@ -30,17 +30,17 @@ syscall_init (void) {
 			((uint64_t)SEL_KCSEG) << 32);
 	write_msr(MSR_LSTAR, (uint64_t) syscall_entry);
 
-	/* The interrupt service rountine should not serve any interrupts
-	 * until the syscall_entry swaps the userland stack to the kernel
-	 * mode stack. Therefore, we masked the FLAG_FL. */
+	/* syscall_entry가 사용자 영역 스택을 커널 모드 스택으로 교체하기 전까지
+	 * 인터럽트 서비스 루틴이 어떤 인터럽트도 처리하면 안 된다.
+	 * 따라서 FLAG_FL을 마스킹한다. */
 	write_msr(MSR_SYSCALL_MASK,
 			FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
 }
 
-/* The main system call interface */
+/* 주 시스템 콜 인터페이스. */
 void
 syscall_handler (struct intr_frame *f UNUSED) {
-	// TODO: Your implementation goes here.
+	// TODO: 구현 내용을 여기에 작성한다.
 	printf ("system call!\n");
 	thread_exit ();
 }

--- a/pintos/userprog/targets.mk
+++ b/pintos/userprog/targets.mk
@@ -1,6 +1,6 @@
-userprog_SRC  = userprog/process.c	# Process loading.
-userprog_SRC += userprog/exception.c	# User exception handler.
-userprog_SRC += userprog/syscall-entry.S # System call entry.
-userprog_SRC += userprog/syscall.c	# System call handler.
-userprog_SRC += userprog/gdt.c		# GDT initialization.
-userprog_SRC += userprog/tss.c		# TSS management.
+userprog_SRC  = userprog/process.c	# 프로세스 로딩.
+userprog_SRC += userprog/exception.c	# 사용자 예외 핸들러.
+userprog_SRC += userprog/syscall-entry.S # 시스템 콜 진입점.
+userprog_SRC += userprog/syscall.c	# 시스템 콜 핸들러.
+userprog_SRC += userprog/gdt.c		# GDT 초기화.
+userprog_SRC += userprog/tss.c		# TSS 관리.

--- a/pintos/userprog/tss.c
+++ b/pintos/userprog/tss.c
@@ -7,66 +7,56 @@
 #include "threads/vaddr.h"
 #include "intrinsic.h"
 
-/* The Task-State Segment (TSS).
+/* 태스크 상태 세그먼트(TSS).
  *
- *  Instances of the TSS, an x86-64 specific structure, are used to
- *  define "tasks", a form of support for multitasking built right
- *  into the processor.  However, for various reasons including
- *  portability, speed, and flexibility, most x86-64 OSes almost
- *  completely ignore the TSS.  We are no exception.
+ *  x86-64 전용 구조체인 TSS의 인스턴스는 프로세서에 내장된 멀티태스킹
+ *  지원 형태인 "태스크"를 정의하는 데 사용된다. 하지만 이식성, 속도,
+ *  유연성 등 여러 이유로 대부분의 x86-64 OS는 TSS를 거의 완전히
+ *  무시한다. 우리도 예외가 아니다.
  *
- *  Unfortunately, there is one thing that can only be done using
- *  a TSS: stack switching for interrupts that occur in user mode.
- *  When an interrupt occurs in user mode (ring 3), the processor
- *  consults the rsp0 members of the current TSS to determine the
- *  stack to use for handling the interrupt.  Thus, we must create
- *  a TSS and initialize at least these fields, and this is
- *  precisely what this file does.
+ *  다만 TSS로만 할 수 있는 일이 하나 있다. 사용자 모드에서 발생한
+ *  인터럽트에 대한 스택 전환이다. 사용자 모드(ring 3)에서 인터럽트가
+ *  발생하면 프로세서는 현재 TSS의 rsp0 멤버를 참고하여 인터럽트 처리에
+ *  사용할 스택을 결정한다. 따라서 TSS를 만들고 적어도 이 필드들을
+ *  초기화해야 하며, 이 파일이 바로 그 일을 한다.
  *
- *  When an interrupt is handled by an interrupt or trap gate
- *  (which applies to all interrupts we handle), an x86-64 processor
- *  works like this:
+ *  인터럽트가 인터럽트 게이트 또는 트랩 게이트를 통해 처리될 때
+ *  (우리가 처리하는 모든 인터럽트가 여기에 해당한다), x86-64 프로세서는
+ *  다음과 같이 동작한다.
  *
- *    - If the code interrupted by the interrupt is in the same
- *      ring as the interrupt handler, then no stack switch takes
- *      place.  This is the case for interrupts that happen when
- *      we're running in the kernel.  The contents of the TSS are
- *      irrelevant for this case.
+ *    - 인터럽트로 중단된 코드가 인터럽트 핸들러와 같은 ring에 있다면
+ *      스택 전환은 일어나지 않는다. 커널에서 실행 중일 때 발생하는
+ *      인터럽트가 이 경우다. 이 경우 TSS의 내용은 관련이 없다.
  *
- *    - If the interrupted code is in a different ring from the
- *      handler, then the processor switches to the stack
- *      specified in the TSS for the new ring.  This is the case
- *      for interrupts that happen when we're in user space.  It's
- *      important that we switch to a stack that's not already in
- *      use, to avoid corruption.  Because we're running in user
- *      space, we know that the current process's kernel stack is
- *      not in use, so we can always use that.  Thus, when the
- *      scheduler switches threads, it also changes the TSS's
- *      stack pointer to point to the new thread's kernel stack.
- *      (The call is in schedule in thread.c.) */
+ *    - 중단된 코드가 핸들러와 다른 ring에 있다면 프로세서는 새 ring에
+ *      대해 TSS에 지정된 스택으로 전환한다. 사용자 공간에 있을 때
+ *      발생하는 인터럽트가 이 경우다. 손상을 피하려면 이미 사용 중이지
+ *      않은 스택으로 전환하는 것이 중요하다. 사용자 공간에서 실행 중이면
+ *      현재 프로세스의 커널 스택은 사용 중이 아님을 알 수 있으므로 항상
+ *      그 스택을 사용할 수 있다. 따라서 스케줄러가 스레드를 전환할 때
+ *      TSS의 스택 포인터도 새 스레드의 커널 스택을 가리키도록 바꾼다.
+ *      (이 호출은 thread.c의 schedule에 있다.) */
 
-/* Kernel TSS. */
+/* 커널 TSS. */
 struct task_state *tss;
 
-/* Initializes the kernel TSS. */
+/* 커널 TSS를 초기화한다. */
 void
 tss_init (void) {
-	/* Our TSS is never used in a call gate or task gate, so only a
-	 * few fields of it are ever referenced, and those are the only
-	 * ones we initialize. */
+	/* 우리의 TSS는 호출 게이트나 태스크 게이트에서 절대 사용되지 않으므로,
+	 * 실제로 참조되는 필드는 몇 개뿐이다. 따라서 그 필드들만 초기화한다. */
 	tss = palloc_get_page (PAL_ASSERT | PAL_ZERO);
 	tss_update (thread_current ());
 }
 
-/* Returns the kernel TSS. */
+/* 커널 TSS를 반환한다. */
 struct task_state *
 tss_get (void) {
 	ASSERT (tss != NULL);
 	return tss;
 }
 
-/* Sets the ring 0 stack pointer in the TSS to point to the end
- * of the thread stack. */
+/* TSS의 ring 0 스택 포인터가 스레드 스택의 끝을 가리키도록 설정한다. */
 void
 tss_update (struct thread *next) {
 	ASSERT (tss != NULL);


### PR DESCRIPTION
## 변경 사항
- userprog 관련 9개 파일의 영어 주석과 Makefile 코멘트를 한국어로 번역했습니다.
- 코드 로직은 변경하지 않고 문서성 텍스트만 옮겼습니다.

## 검증
- git diff --check
- 주석/코멘트 제거 후 원본과 비주석 소스 내용이 동일한지 확인
- make -C pintos/userprog 실행 시도: macOS arm64 clang 환경에서 Pintos x86 옵션 -mno-sse 미지원으로 중단됨