### PR TITLE
fix: Gemini Code Assist 설정 파일 수정

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,55 +1,13 @@
-$schema: "http://json-schema.org/draft-07/schema#"
-title: RepoConfig
-description: Configuration for Gemini Code Assist on a repository. All fields are optional and have default values.
-type: object
-properties:
-  have_fun:
-    type: boolean
-    description: Enables fun features such as a poem in the initial pull request summary. Default: false.
-  ignore_patterns:
-    type: array
-    items:
-      type: string
-    description: A list of glob patterns for files and directories that Gemini Code Assist should ignore. Default: [].
-  memory_config:
-    type: object
-    description: Configuration for persistent memory, which is used to improve responses.
-    properties:
-      disabled:
-        type: boolean
-        description: Whether to disable persistent memory for this specific repository. Default: false.
-  code_review:
-    type: object
-    description: Configuration for code reviews. All fields are optional and have default values.
-    properties:
-      disable:
-        type: boolean
-        description: Disables Gemini from acting on pull requests. Default: false.
-      comment_severity_threshold:
-        type: string
-        enum:
-          - LOW
-          - MEDIUM
-          - HIGH
-          - CRITICAL
-        description: The minimum severity of review comments to consider. Default: MEDIUM.
-      max_review_comments:
-        type: integer
-        format: int64
-        description: The maximum number of review comments to consider. Use -1 for unlimited. Default: -1.
-      pull_request_opened:
-        type: object
-        description: Configuration for pull request opened events. All fields are optional and have default values.
-        properties:
-          help:
-            type: boolean
-            description: Posts a help message on pull request open. Default: false.
-          summary:
-            type: boolean
-            description: Posts a pull request summary on the pull request open. Default: false.
-          code_review:
-            type: boolean
-            description: Posts a code review on pull request open. Default: true.
-          include_drafts:
-            type: boolean
-            description: Enables agent functionality on draft pull requests. Default: true.
+have_fun: false
+memory_config:
+  disabled: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: true
+ignore_patterns: []


### PR DESCRIPTION
## 변경 사항
- .gemini/config.yaml에 들어 있던 JSON Schema 본문을 실제 Gemini Code Assist 설정값으로 교체했습니다.
- PR 생성 시 Gemini 요약과 코드 리뷰가 실행되도록 pull_request_opened 설정을 활성화했습니다.

## 원인
- 기존 파일은 공식 문서의 config.yaml schema 예시가 그대로 들어가 있어 Gemini가 설정 파일로 사용할 수 없었습니다.

## 검증
- PyYAML로 .gemini/config.yaml 파싱 확인