### PR TITLE
fix: userprog exec/wait 흐름 구현

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pintos/tests/userprog/sample.txt text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-pintos/tests/userprog/sample.txt text eol=lf

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -7,10 +7,13 @@
 #include <stdbool.h>
 #include "threads/fixed-point.h"
 #include "threads/interrupt.h"
+#include "threads/synch.h"
+
 #ifdef VM
 #include "vm/vm.h"
 #endif
 
+struct file;
 
 /* 스레드 수명 주기의 상태입니다. */
 enum thread_status {
@@ -25,10 +28,22 @@ enum thread_status {
 typedef int tid_t;
 #define TID_ERROR ((tid_t) -1)          /* tid_t의 오류 값. */
 
+#ifdef USERPROG
+struct child_status {
+	tid_t tid;
+	int exit_status;
+	bool waited;
+	bool exited;
+	struct semaphore wait_sema;
+	struct list_elem elem;
+};
+#endif
+
 /* 스레드 우선순위. */
 #define PRI_MIN 0                       /* 가장 낮은 우선순위. */
 #define PRI_DEFAULT 31                  /* 기본 우선순위. */
 #define PRI_MAX 63                      /* 가장 높은 우선순위. */
+#define FD_MAX 32
 
 /* 커널 스레드 또는 사용자 프로세스.
  *
@@ -116,9 +131,19 @@ struct thread {
 	fp32_t recent_cpu;
 	struct list_elem q_elem;
 
+	struct semaphore load_sema;
+	bool load_success;
+	int exit_status;
+
 #ifdef USERPROG
 	/* userprog/process.c가 소유합니다. */
 	uint64_t *pml4;                     /* 페이지 맵 레벨 4 */
+	struct thread *parent;
+	struct list children;
+	struct child_status *child_status;
+	struct file *running_file;
+	struct file *fd_table[FD_MAX];
+	int next_fd;
 #endif
 #ifdef VM
 	/* 스레드가 소유한 전체 가상 메모리에 대한 테이블입니다. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -138,13 +138,14 @@ thread_init (void) {
 	list_init (&destruction_req);
 	list_init (&all_thread_list);
 	load_avg = fp (0);
-
+	
 	/* 실행 중인 스레드에 대한 스레드 구조를 설정합니다. */
 	initial_thread = running_thread ();
 	init_thread (initial_thread, "main", PRI_DEFAULT);
 	initial_thread->status = THREAD_RUNNING;
 	initial_thread->tid = allocate_tid ();
-
+	sema_init (&initial_thread->load_sema, 0);
+	
 	if (thread_mlfqs)
 		list_push_back (&all_thread_list, &initial_thread->q_elem);
 }
@@ -528,7 +529,15 @@ init_thread (struct thread *t, const char *name, int priority) {
 	}
 	t->magic = THREAD_MAGIC;
 	t->wait_on_lock = NULL;
+	sema_init (&t->load_sema, 0);
 	list_init (&t->donations);
+#ifdef USERPROG
+	t->parent = NULL;
+	t->child_status = NULL;
+	t->running_file = NULL;
+	t->next_fd = 2;
+	list_init (&t->children);
+#endif
 }
 
 /* 예약할 다음 스레드를 선택하고 반환합니다. 해야 한다

--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -74,6 +74,7 @@ kill (struct intr_frame *f) {
 	   알려준다. */
 	switch (f->cs) {
 		case SEL_UCSEG:
+			thread_current ()->exit_status = -1;
 			/* 사용자 코드 세그먼트이므로 예상대로 사용자 예외다.
 			   사용자 프로세스를 종료한다. */
 			printf ("%s: dying due to interrupt %#04llx (%s).\n",

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -194,7 +194,7 @@ __do_fork (void *aux) {
 	if_.R.rax = 0;
 
 	/* 2. 페이지 테이블을 복제한다. */
-	current->pml4 = pml4_create();
+	current->pml4 = pml4_create ();
 	if (current->pml4 == NULL)
 		goto error;
 
@@ -334,7 +334,7 @@ process_wait (tid_t child_tid) {
 
 	if (thread_current ()->pml4 != NULL)
 		return -1;
-	sema_down(&initd_wait_sema);
+	sema_down (&initd_wait_sema);
 
 	/*
 		wait-simple, wait-twice, wait-bad-pid, wait-killed까지 가려면

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -13,19 +13,34 @@
 #include "threads/flags.h"
 #include "threads/init.h"
 #include "threads/interrupt.h"
+#include "threads/malloc.h"
 #include "threads/palloc.h"
 #include "threads/thread.h"
 #include "threads/mmu.h"
 #include "threads/vaddr.h"
+#include "threads/synch.h"
 #include "intrinsic.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
 
+static struct semaphore initd_wait_sema;
+
+struct fork_aux {
+	struct thread *parent;
+	struct intr_frame parent_if;
+	struct child_status *status;
+	struct semaphore start_sema;
+	struct semaphore done_sema;
+	bool success;
+};
+
 static void process_cleanup (void);
 static bool load (const char *file_name, struct intr_frame *if_);
+static bool setup_argument_stack (struct intr_frame *if_, char *argv[], int argc);
 static void initd (void *f_name);
 static void __do_fork (void *);
+static struct child_status *find_child_status (tid_t child_tid);
 
 #define MAX_ARGC 128
 
@@ -43,6 +58,7 @@ tid_t
 process_create_initd (const char *file_name) {
 	char *fn_copy;
 	tid_t tid;
+	sema_init (&initd_wait_sema, 0);
 
 	/* FILE_NAME의 복사본을 만든다.
 	 * 그렇지 않으면 호출자와 load() 사이에 경쟁 상태가 생긴다. */
@@ -75,10 +91,49 @@ initd (void *f_name) {
 /* 현재 프로세스를 `name`으로 복제한다. 새 프로세스의 스레드 id를 반환하며,
  * 스레드를 만들 수 없으면 TID_ERROR를 반환한다. */
 tid_t
-process_fork (const char *name, struct intr_frame *if_ UNUSED) {
-	/* 현재 스레드를 새 스레드로 복제한다. */
-	return thread_create (name,
-			PRI_DEFAULT, __do_fork, thread_current ());
+process_fork (const char *name, struct intr_frame *if_) {
+	struct fork_aux *aux;
+	struct child_status *status;
+	tid_t tid;
+
+	aux = malloc (sizeof *aux);
+	status = malloc (sizeof *status);
+	if (aux == NULL || status == NULL) {
+		free (aux);
+		free (status);
+		return TID_ERROR;
+	}
+
+	status->tid = TID_ERROR;
+	status->exit_status = -1;
+	status->waited = false;
+	status->exited = false;
+	sema_init (&status->wait_sema, 0);
+
+	aux->parent = thread_current ();
+	aux->parent_if = *if_;
+	aux->status = status;
+	aux->success = false;
+	sema_init (&aux->start_sema, 0);
+	sema_init (&aux->done_sema, 0);
+
+	list_push_back (&thread_current ()->children, &status->elem);
+	tid = thread_create (name, PRI_DEFAULT, __do_fork, aux);
+	if (tid == TID_ERROR) {
+		list_remove (&status->elem);
+		free (status);
+		free (aux);
+		return TID_ERROR;
+	}
+
+	status->tid = tid;
+	sema_up (&aux->start_sema);
+	sema_down (&aux->done_sema);
+
+	if (!aux->success)
+		tid = TID_ERROR;
+	free (aux);
+	return tid;
 }
 
 #ifndef VM
@@ -92,21 +147,26 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	void *newpage;
 	bool writable;
 
-	/* 1. TODO: parent_page가 커널 페이지라면 즉시 반환한다. */
+	if (is_kern_pte (pte))
+		return true;
 
 	/* 2. 부모의 페이지 맵 레벨 4에서 VA를 해석한다. */
 	parent_page = pml4_get_page (parent->pml4, va);
+	if (parent_page == NULL)
+		return true;
 
-	/* 3. TODO: 자식을 위한 새 PAL_USER 페이지를 할당하고 결과를
-	 *    TODO: NEWPAGE에 설정한다. */
+	newpage = palloc_get_page (PAL_USER);
+	if (newpage == NULL)
+		return false;
 
-	/* 4. TODO: 부모의 페이지를 새 페이지로 복제하고, 부모 페이지가 쓰기
-	 *    TODO: 가능한지 확인한다(결과에 따라 WRITABLE을 설정한다). */
+	memcpy (newpage, parent_page, PGSIZE);
+	writable = is_writable (pte);
 
 	/* 5. 새 페이지를 자식의 페이지 테이블에 VA 주소와 WRITABLE 권한으로
 	 *    추가한다. */
 	if (!pml4_set_page (current->pml4, va, newpage, writable)) {
-		/* 6. TODO: 페이지 삽입에 실패하면 오류 처리를 수행한다. */
+		palloc_free_page (newpage);
+		return false;
 	}
 	return true;
 }
@@ -117,15 +177,21 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
  *       즉, process_fork의 두 번째 인자를 이 함수에 전달해야 한다. */
 static void
 __do_fork (void *aux) {
+	struct fork_aux *fork_aux = aux;
 	struct intr_frame if_;
-	struct thread *parent = (struct thread *) aux;
+	struct thread *parent;
 	struct thread *current = thread_current ();
 	/* TODO: 어떤 방식으로든 parent_if를 전달한다. (즉, process_fork()의 if_) */
-	struct intr_frame *parent_if;
 	bool succ = true;
 
 	/* 1. CPU 컨텍스트를 로컬 스택으로 읽는다. */
-	memcpy (&if_, parent_if, sizeof (struct intr_frame));
+	sema_down (&fork_aux->start_sema);
+	parent = fork_aux->parent;
+	current->parent = parent;
+	current->child_status = fork_aux->status;
+
+	memcpy (&if_, &fork_aux->parent_if, sizeof if_);
+	if_.R.rax = 0;
 
 	/* 2. 페이지 테이블을 복제한다. */
 	current->pml4 = pml4_create();
@@ -142,6 +208,15 @@ __do_fork (void *aux) {
 		goto error;
 #endif
 
+	for (int fd = 2; fd < FD_MAX; fd++) {
+		if (parent->fd_table[fd] != NULL) {
+			current->fd_table[fd] = file_duplicate (parent->fd_table[fd]);
+			if (current->fd_table[fd] == NULL)
+				goto error;
+		}
+	}
+	current->next_fd = parent->next_fd;
+
 	/* TODO: 구현 내용을 여기에 작성한다.
 	 * TODO: 힌트) 파일 객체를 복제하려면 include/filesys/file.h의
 	 * TODO:       `file_duplicate`를 사용한다. 이 함수가 부모의 리소스를
@@ -151,9 +226,14 @@ __do_fork (void *aux) {
 	process_init ();
 
 	/* 마지막으로 새로 생성한 프로세스로 전환한다. */
+	fork_aux->success = succ;
+	sema_up (&fork_aux->done_sema);
+
 	if (succ)
 		do_iret (&if_);
 error:
+	fork_aux->success = false;
+	sema_up (&fork_aux->done_sema);
 	thread_exit ();
 }
 
@@ -177,55 +257,13 @@ parse_command_line (char *cmdline, char **argv) {
 	return count;
 }
 
-static void
-setup_argument_stack (char **argv, int argc, struct intr_frame *if_) {
-	int count = argc - 1;
-	char *arg_addr[MAX_ARGC];
-
-	while (count >= 0) {
-		char *item = argv[count];
-		size_t len = strlen (item) + 1;
-		if_->rsp -= len;
-
-		memcpy ((void *) if_->rsp, item, len);
-		arg_addr[count] = (char *) if_->rsp;
-		count--;
-	}
-	arg_addr[argc] = NULL;
-
-	while (if_->rsp % sizeof (uint64_t) != 0) {
-		if_->rsp--;
-		*(uint8_t *) if_->rsp = 0;
-	}
-
-	count = argc;
-	while (count >= 0) {
-		if_->rsp -= sizeof (uint64_t);
-		memcpy ((void *) if_->rsp, &arg_addr[count], sizeof (arg_addr[count]));
-		count--;
-	}
-
-	char *start_pt = (char *) if_->rsp;
-	if_->R.rdi = (uint64_t) argc;
-	if_->R.rsi = (uint64_t) start_pt;
-
-	while (if_->rsp % sizeof (uint64_t) != 0) {
-		if_->rsp--;
-		*(uint8_t *) if_->rsp = 0;
-	}
-
-	uint64_t zero = 0;
-	if_->rsp -= sizeof (uint64_t);
-	memcpy ((void *) if_->rsp, &zero, sizeof (zero));
-}
-
 /* 현재 실행 컨텍스트를 f_name으로 전환한다.
  * 실패하면 -1을 반환한다. */
 int
 process_exec (void *f_name) {
-	ASSERT (f_name != NULL);
-
-	char *file_name = f_name;
+	char *cmd_line = f_name;
+	char *argv[MAX_ARGC];
+	int argc;
 	bool success;
 
 	/* thread 구조체 안의 intr_frame은 사용할 수 없다.
@@ -236,25 +274,24 @@ process_exec (void *f_name) {
 	_if.cs = SEL_UCSEG;
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
-	/* 먼저 현재 컨텍스트를 제거한다. */
-	process_cleanup ();
-
-	char *argv[MAX_ARGC];
-	int argc = parse_command_line (file_name, argv);
-	if (argc == -1) {
-		palloc_free_page (file_name);
+	argc = parse_command_line (cmd_line, argv);
+	if (argc <= 0) {
+		palloc_free_page (cmd_line);
 		return -1;
 	}
 
+	/* 먼저 현재 컨텍스트를 제거한다. */
+	process_cleanup ();
+
 	/* 그런 다음 바이너리를 로드한다. */
 	success = load (argv[0], &_if);
-	palloc_free_page (file_name);
+	if (success)
+		setup_argument_stack (&_if, argv, argc);
 
 	/* load에 실패했으면 종료한다. */
+	palloc_free_page (cmd_line);
 	if (!success)
 		return -1;
-
-	setup_argument_stack (argv, argc, &_if);
 
 	/* 전환된 프로세스를 시작한다. */
 	do_iret (&_if);
@@ -269,16 +306,58 @@ process_exec (void *f_name) {
  * -1을 반환한다.
  *
  * 이 함수는 문제 2-2에서 구현된다. 지금은 아무 일도 하지 않는다. */
+// initial process 종료 흐름, child record 후보 정리 user program 테스트가 조기 종료 없이 관찰 가능
+// child record와 wait 설계	최소 process_wait 기준과 exit status 저장 위치가 정해져야 함 / wait-simple, wait-twice, wait-bad-pid, wait-killed expected output 확인
+// exit는 자식이 상태를 남기는 동작이고, wait는 부모가 그 상태를 가져가는 동작이다.
+// 본인의 자식만 wait 가능하다.
+// 같은 자식을 두 번 wait 할 수 없다.
+// 자식이 먼저 죽어도 status는 남아 있어야 한다.
+// 부모가 먼저 죽어도 자식 정리가 깨지면 안 된다.
 int
-process_wait (tid_t child_tid UNUSED) {
+process_wait (tid_t child_tid) {
+	struct child_status *status = find_child_status (child_tid);
+	int exit_status;
+
+	if (status != NULL) {
+		if (status->waited)
+			return -1;
+		status->waited = true;
+		sema_down (&status->wait_sema);
+		exit_status = status->exit_status;
+		list_remove (&status->elem);
+		free (status);
+		return exit_status;
+	}
 	/* XXX: 힌트) process_wait(initd)에서 Pintos가 종료된다. process_wait를
 	 * XXX:       구현하기 전에는 여기에 무한 루프를 추가하는 것을 권장한다. */
-	while (1) {
-	}
-	return -1;
+	// initial process가 child 종료 전에 Pintos를 끝내지 않는다.
+
+	if (thread_current ()->pml4 != NULL)
+		return -1;
+	sema_down(&initd_wait_sema);
+
+	/*
+		wait-simple, wait-twice, wait-bad-pid, wait-killed까지 가려면
+		전역 세마포어 하나로는 부족하고, 자식마다 exit_status, wait_sema, waited, child list 필요
+	*/
+	return 0;
 }
 
 /* 프로세스를 종료한다. 이 함수는 thread_exit()에서 호출된다. */
+static struct child_status *
+find_child_status (tid_t child_tid) {
+	struct thread *curr = thread_current ();
+	struct list_elem *e;
+
+	for (e = list_begin (&curr->children); e != list_end (&curr->children);
+			e = list_next (e)) {
+		struct child_status *status = list_entry (e, struct child_status, elem);
+		if (status->tid == child_tid)
+			return status;
+	}
+	return NULL;
+}
+
 void
 process_exit (void) {
 	struct thread *curr = thread_current ();
@@ -286,6 +365,20 @@ process_exit (void) {
 	 * TODO: 프로세스 종료 메시지를 구현한다
 	 * TODO: (project2/process_termination.html 참고).
 	 * TODO: 여기에서 프로세스 리소스 정리를 구현하는 것을 권장한다. */
+	printf ("%s: exit(%d)\n", curr->name, curr->exit_status);
+	if (curr->child_status != NULL) {
+		curr->child_status->exit_status = curr->exit_status;
+		curr->child_status->exited = true;
+		sema_up (&curr->child_status->wait_sema);
+	}
+	for (int fd = 2; fd < FD_MAX; fd++) {
+		if (curr->fd_table[fd] != NULL) {
+			file_close (curr->fd_table[fd]);
+			curr->fd_table[fd] = NULL;
+		}
+	}
+	if (curr->parent == NULL)
+		sema_up(&initd_wait_sema);
 
 	process_cleanup ();
 }
@@ -294,6 +387,11 @@ process_exit (void) {
 static void
 process_cleanup (void) {
 	struct thread *curr = thread_current ();
+
+	if (curr->running_file != NULL) {
+		file_close (curr->running_file);
+		curr->running_file = NULL;
+	}
 
 #ifdef VM
 	supplemental_page_table_kill (&curr->spt);
@@ -485,11 +583,14 @@ load (const char *file_name, struct intr_frame *if_) {
 	/* TODO: 구현 내용을 여기에 작성한다.
 	 * TODO: 인자 전달을 구현한다(project2/argument_passing.html 참고). */
 
+	file_deny_write (file);
+	t->running_file = file;
 	success = true;
 
 done:
 	/* load 성공 여부와 관계없이 여기로 도착한다. */
-	file_close (file);
+	if (!success)
+		file_close (file);
 	return success;
 }
 
@@ -614,6 +715,37 @@ setup_stack (struct intr_frame *if_) {
 			palloc_free_page (kpage);
 	}
 	return success;
+}
+
+static bool
+setup_argument_stack (struct intr_frame *if_, char *argv[], int argc) {
+	uint64_t rsp = if_->rsp;
+	char *uargv[MAX_ARGC];
+
+	for (int i = argc - 1; i >= 0; i--) {
+		size_t len = strlen (argv[i]) + 1;
+		rsp -= len;
+		memcpy ((void *) rsp, argv[i], len);
+		uargv[i] = (char *) rsp;
+	}
+
+	while (rsp % 8 != 0) {
+		rsp--;
+		*(uint8_t *) rsp = 0;
+	}
+
+	rsp -= sizeof (char *);
+	*(char **) rsp = NULL;
+
+	for (int i = argc - 1; i >= 0; i--) {
+		rsp -= sizeof (char *);
+		*(char **) rsp = uargv[i];
+	}
+
+	if_->R.rdi = argc;
+	if_->R.rsi = rsp;
+	if_->rsp = rsp;
+	return true;
 }
 
 /* 사용자 가상 주소 UPAGE에서 커널 가상 주소 KPAGE로의 매핑을 페이지

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -2,22 +2,14 @@
 #include <stdio.h>
 #include <syscall-nr.h>
 #include "threads/interrupt.h"
-#include "threads/palloc.h"
 #include "threads/thread.h"
 #include "threads/loader.h"
-#include "threads/mmu.h"
 #include "userprog/gdt.h"
-#include "userprog/process.h"
 #include "threads/flags.h"
 #include "intrinsic.h"
 #include "threads/synch.h"
-#include "threads/vaddr.h"
-#include "filesys/file.h"
-#include "filesys/filesys.h"
-#include "lib/kernel/stdio.h"
-#include <string.h>
 
-#define NO_RETURN_VAL (-0x7fffffffffffffffLL - 1)
+#define NO_RETURN_VAL (-1)
 
 struct syscall_entry {
 	/* system call number */
@@ -26,7 +18,7 @@ struct syscall_entry {
 	/* return value (optional, default: NO_RETURN_VAL) */
 	/* 반환값이 필요한 경우 handle_{syscall_name} 함수에서
 	   설정함 */
-	int64_t return_value;
+	uint64_t return_value;
 
 	/* arguments */
 	/* Linux x86-64 system call ABI에선 인자를 6개로 제한함 */
@@ -51,9 +43,6 @@ static void handle_write (struct intr_frame *, struct syscall_entry *);
 static void handle_seek (struct intr_frame *, struct syscall_entry *);
 static void handle_tell (struct intr_frame *, struct syscall_entry *);
 static void handle_close (struct intr_frame *, struct syscall_entry *);
-static bool validate_user_string (const char *);
-static bool validate_user_buffer (const void *, unsigned);
-static void exit_with_status (int status);
 
 /* 시스템 콜.
  *
@@ -157,41 +146,6 @@ dispatch_syscall (struct intr_frame *f, struct syscall_entry *entry) {
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
-static bool
-validate_user_string (const char *str) {
-	if (str == NULL)
-		return false;
-
-	for (;;) {
-		if (!is_user_vaddr (str) ||
-				pml4_get_page (thread_current ()->pml4, str) == NULL)
-			return false;
-		if (*str == '\0')
-			return true;
-		str++;
-	}
-}
-
-static bool
-validate_user_buffer (const void *buffer, unsigned size) {
-	const char *ptr = buffer;
-
-	if (buffer == NULL)
-		return false;
-	for (unsigned i = 0; i < size; i++) {
-		if (!is_user_vaddr (ptr + i) ||
-				pml4_get_page (thread_current ()->pml4, ptr + i) == NULL)
-			return false;
-	}
-	return true;
-}
-
-static void
-exit_with_status (int status) {
-	thread_current ()->exit_status = status;
-	thread_exit ();
-}
-
 static void
 handle_halt (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 	barrier ();
@@ -199,13 +153,13 @@ handle_halt (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 }
 
 static void
-handle_exit (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
+handle_exit (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 	exit_with_status ((int) entry->args[0]);
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_fork (struct intr_frame *f, struct syscall_entry *entry) {
+handle_fork (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 	const char *thread_name = (const char *) entry->args[0];
 
 	if (!validate_user_string (thread_name)) {
@@ -214,39 +168,20 @@ handle_fork (struct intr_frame *f, struct syscall_entry *entry) {
 	}
 	entry->return_value = process_fork (thread_name, f);
 	return;
+}
+
+/* TODO: 구현하면 UNUSED, ASSERT 빼기 */
+static void
+handle_exec (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 	barrier ();
 	ASSERT (false); /* 현재 처리할 수 없는 syscall */
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_exec (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
-	const char *cmd_line = (const char *) entry->args[0];
-	char *cmd_copy;
-
-	if (!validate_user_string (cmd_line))
-		exit_with_status (-1);
-
-	cmd_copy = palloc_get_page (0);
-	if (cmd_copy == NULL) {
-		entry->return_value = -1;
-		return;
-	}
-	strlcpy (cmd_copy, cmd_line, PGSIZE);
-
-	entry->return_value = process_exec (cmd_copy);
-	if (entry->return_value == -1) {
-		exit_with_status (-1);
-	}
-}
-
-/* TODO: 구현하면 UNUSED, ASSERT 빼기 */
-static void
-handle_wait (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
+handle_wait (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 	entry->return_value = process_wait ((tid_t) entry->args[0]);
 	return;
-	barrier ();
-	ASSERT (false); /* 현재 처리할 수 없는 syscall */
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
@@ -267,35 +202,7 @@ handle_remove (struct intr_frame *f UNUSED,
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_open (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
-	const char *file_name = (const char *) entry->args[0];
-	struct thread *curr = thread_current ();
-	struct file *file;
-	int fd;
-
-	if (!validate_user_string (file_name)) {
-		entry->return_value = -1;
-		return;
-	}
-
-	file = filesys_open (file_name);
-	if (file == NULL) {
-		entry->return_value = -1;
-		return;
-	}
-
-	for (fd = curr->next_fd; fd < FD_MAX; fd++) {
-		if (curr->fd_table[fd] == NULL) {
-			curr->fd_table[fd] = file;
-			curr->next_fd = fd + 1;
-			entry->return_value = fd;
-			return;
-		}
-	}
-
-	file_close (file);
-	entry->return_value = -1;
-	return;
+handle_open (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 	barrier ();
 	ASSERT (false); /* 현재 처리할 수 없는 syscall */
 }
@@ -310,38 +217,16 @@ handle_filesize (struct intr_frame *f UNUSED,
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_read (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
-	int fd = (int) entry->args[0];
-	void *buffer = (void *) entry->args[1];
-	unsigned size = (unsigned) entry->args[2];
-	struct thread *curr = thread_current ();
-
-	if (!validate_user_buffer (buffer, size))
-		exit_with_status (-1);
-	if (fd < 2 || fd >= FD_MAX || curr->fd_table[fd] == NULL) {
-		entry->return_value = -1;
-		return;
-	}
-
-	entry->return_value = file_read (curr->fd_table[fd], buffer, size);
-	return;
+handle_read (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 	barrier ();
 	ASSERT (false); /* 현재 처리할 수 없는 syscall */
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_write (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
-	int fd = (int) entry->args[0];
-	const void *buffer = (const void *) entry->args[1];
-	unsigned size = (unsigned) entry->args[2];
-
-	if (fd == 1) {
-		putbuf (buffer, size);
-		entry->return_value = size;
-	} else {
-		entry->return_value = -1;
-	}
+handle_write (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
+	barrier ();
+	ASSERT (false); /* 현재 처리할 수 없는 syscall */
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
@@ -360,7 +245,7 @@ handle_tell (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_close (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
+handle_close (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 	int fd = (int) entry->args[0];
 	struct thread *curr = thread_current ();
 
@@ -371,6 +256,4 @@ handle_close (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
 			curr->next_fd = fd;
 	}
 	return;
-	barrier ();
-	ASSERT (false); /* 현재 처리할 수 없는 syscall */
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -2,14 +2,22 @@
 #include <stdio.h>
 #include <syscall-nr.h>
 #include "threads/interrupt.h"
+#include "threads/palloc.h"
 #include "threads/thread.h"
 #include "threads/loader.h"
+#include "threads/mmu.h"
 #include "userprog/gdt.h"
+#include "userprog/process.h"
 #include "threads/flags.h"
 #include "intrinsic.h"
 #include "threads/synch.h"
+#include "threads/vaddr.h"
+#include "filesys/file.h"
+#include "filesys/filesys.h"
+#include "lib/kernel/stdio.h"
+#include <string.h>
 
-#define NO_RETURN_VAL (-1)
+#define NO_RETURN_VAL (-0x7fffffffffffffffLL - 1)
 
 struct syscall_entry {
 	/* system call number */
@@ -18,7 +26,7 @@ struct syscall_entry {
 	/* return value (optional, default: NO_RETURN_VAL) */
 	/* 반환값이 필요한 경우 handle_{syscall_name} 함수에서
 	   설정함 */
-	uint64_t return_value;
+	int64_t return_value;
 
 	/* arguments */
 	/* Linux x86-64 system call ABI에선 인자를 6개로 제한함 */
@@ -43,6 +51,9 @@ static void handle_write (struct intr_frame *, struct syscall_entry *);
 static void handle_seek (struct intr_frame *, struct syscall_entry *);
 static void handle_tell (struct intr_frame *, struct syscall_entry *);
 static void handle_close (struct intr_frame *, struct syscall_entry *);
+static bool validate_user_string (const char *);
+static bool validate_user_buffer (const void *, unsigned);
+static void exit_with_status (int status);
 
 /* 시스템 콜.
  *
@@ -146,6 +157,41 @@ dispatch_syscall (struct intr_frame *f, struct syscall_entry *entry) {
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
+static bool
+validate_user_string (const char *str) {
+	if (str == NULL)
+		return false;
+
+	for (;;) {
+		if (!is_user_vaddr (str) ||
+				pml4_get_page (thread_current ()->pml4, str) == NULL)
+			return false;
+		if (*str == '\0')
+			return true;
+		str++;
+	}
+}
+
+static bool
+validate_user_buffer (const void *buffer, unsigned size) {
+	const char *ptr = buffer;
+
+	if (buffer == NULL)
+		return false;
+	for (unsigned i = 0; i < size; i++) {
+		if (!is_user_vaddr (ptr + i) ||
+				pml4_get_page (thread_current ()->pml4, ptr + i) == NULL)
+			return false;
+	}
+	return true;
+}
+
+static void
+exit_with_status (int status) {
+	thread_current ()->exit_status = status;
+	thread_exit ();
+}
+
 static void
 handle_halt (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 	barrier ();
@@ -153,28 +199,52 @@ handle_halt (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 }
 
 static void
-handle_exit (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
+handle_exit (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
+	exit_with_status ((int) entry->args[0]);
+}
+
+/* TODO: 구현하면 UNUSED, ASSERT 빼기 */
+static void
+handle_fork (struct intr_frame *f, struct syscall_entry *entry) {
+	const char *thread_name = (const char *) entry->args[0];
+
+	if (!validate_user_string (thread_name)) {
+		entry->return_value = -1;
+		return;
+	}
+	entry->return_value = process_fork (thread_name, f);
+	return;
 	barrier ();
 	ASSERT (false); /* 현재 처리할 수 없는 syscall */
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_fork (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
-	barrier ();
-	ASSERT (false); /* 현재 처리할 수 없는 syscall */
+handle_exec (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
+	const char *cmd_line = (const char *) entry->args[0];
+	char *cmd_copy;
+
+	if (!validate_user_string (cmd_line))
+		exit_with_status (-1);
+
+	cmd_copy = palloc_get_page (0);
+	if (cmd_copy == NULL) {
+		entry->return_value = -1;
+		return;
+	}
+	strlcpy (cmd_copy, cmd_line, PGSIZE);
+
+	entry->return_value = process_exec (cmd_copy);
+	if (entry->return_value == -1) {
+		exit_with_status (-1);
+	}
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_exec (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
-	barrier ();
-	ASSERT (false); /* 현재 처리할 수 없는 syscall */
-}
-
-/* TODO: 구현하면 UNUSED, ASSERT 빼기 */
-static void
-handle_wait (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
+handle_wait (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
+	entry->return_value = process_wait ((tid_t) entry->args[0]);
+	return;
 	barrier ();
 	ASSERT (false); /* 현재 처리할 수 없는 syscall */
 }
@@ -197,7 +267,35 @@ handle_remove (struct intr_frame *f UNUSED,
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_open (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
+handle_open (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
+	const char *file_name = (const char *) entry->args[0];
+	struct thread *curr = thread_current ();
+	struct file *file;
+	int fd;
+
+	if (!validate_user_string (file_name)) {
+		entry->return_value = -1;
+		return;
+	}
+
+	file = filesys_open (file_name);
+	if (file == NULL) {
+		entry->return_value = -1;
+		return;
+	}
+
+	for (fd = curr->next_fd; fd < FD_MAX; fd++) {
+		if (curr->fd_table[fd] == NULL) {
+			curr->fd_table[fd] = file;
+			curr->next_fd = fd + 1;
+			entry->return_value = fd;
+			return;
+		}
+	}
+
+	file_close (file);
+	entry->return_value = -1;
+	return;
 	barrier ();
 	ASSERT (false); /* 현재 처리할 수 없는 syscall */
 }
@@ -212,16 +310,38 @@ handle_filesize (struct intr_frame *f UNUSED,
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_read (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
+handle_read (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
+	int fd = (int) entry->args[0];
+	void *buffer = (void *) entry->args[1];
+	unsigned size = (unsigned) entry->args[2];
+	struct thread *curr = thread_current ();
+
+	if (!validate_user_buffer (buffer, size))
+		exit_with_status (-1);
+	if (fd < 2 || fd >= FD_MAX || curr->fd_table[fd] == NULL) {
+		entry->return_value = -1;
+		return;
+	}
+
+	entry->return_value = file_read (curr->fd_table[fd], buffer, size);
+	return;
 	barrier ();
 	ASSERT (false); /* 현재 처리할 수 없는 syscall */
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_write (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
-	barrier ();
-	ASSERT (false); /* 현재 처리할 수 없는 syscall */
+handle_write (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
+	int fd = (int) entry->args[0];
+	const void *buffer = (const void *) entry->args[1];
+	unsigned size = (unsigned) entry->args[2];
+
+	if (fd == 1) {
+		putbuf (buffer, size);
+		entry->return_value = size;
+	} else {
+		entry->return_value = -1;
+	}
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
@@ -240,7 +360,17 @@ handle_tell (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_close (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
+handle_close (struct intr_frame *f UNUSED, struct syscall_entry *entry) {
+	int fd = (int) entry->args[0];
+	struct thread *curr = thread_current ();
+
+	if (fd >= 2 && fd < FD_MAX && curr->fd_table[fd] != NULL) {
+		file_close (curr->fd_table[fd]);
+		curr->fd_table[fd] = NULL;
+		if (fd < curr->next_fd)
+			curr->next_fd = fd;
+	}
+	return;
 	barrier ();
 	ASSERT (false); /* 현재 처리할 수 없는 syscall */
 }


### PR DESCRIPTION
## 작업 배경

userprog의 `exec` 관련 테스트는 단순히 `exec()`만 구현해서는 통과하지 않고, `fork()` 이후 자식의 주소 공간 복제, `wait()`의 자식별 종료 상태 회수, 실행 파일 보호, fd 상속까지 함께 맞아야 합니다.

기존 구현은 `process_exec()`의 인자 처리와 cleanup 흐름이 불안정했고, `fork()`/`wait()` syscall이 미구현 상태라 `exec-boundary`, `wait-*`, `exec-read` 계열 테스트에서 실패했습니다.

## 작업 내용

- `process_exec()`의 command line 파싱과 argument stack 구성을 정리했습니다.
- `fork()`에서 부모의 interrupt frame, 유저 페이지, fd table을 자식에게 복제하도록 구현했습니다.
- 자식별 `child_status`를 추가해 `wait(pid)`가 자신의 자식만 한 번 기다리고 exit status를 회수하도록 했습니다.
- 일반 자식 종료가 initd 대기 세마포어를 깨워 Pintos가 조기 종료되던 문제를 수정했습니다.
- 실행 중인 파일에 `file_deny_write()`를 적용하고 종료 시 정리하도록 했습니다.
- `open`, `read`, `close`와 최소 fd table을 구현해 `fork()` 후 `exec()`에서도 열린 fd가 유지되도록 했습니다.
- Windows checkout 환경에서 `exec-read` fixture가 CRLF로 변환되지 않도록 `.gitattributes`에 LF 정책을 추가했습니다.

## 테스트

- `tests/userprog/exec-once.result`
- `tests/userprog/exec-arg.result`
- `tests/userprog/exec-boundary.result`
- `tests/userprog/exec-missing.result`
- `tests/userprog/exec-bad-ptr.result`
- `tests/userprog/exec-read.result`
- `tests/userprog/wait-simple.result`
- `tests/userprog/wait-twice.result`
- `tests/userprog/wait-bad-pid.result`
- `tests/userprog/wait-killed.result`

## 비고

별도 연결 이슈가 없어 `Closes` footer는 포함하지 않았습니다.
