### PR TITLE
feat(userprog): user memory helpers 추가

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Disable Git line-ending conversion by default.
+* -text
+
+# Source files edited locally should keep Linux line endings.
+*.c text eol=lf
+*.h text eol=lf
+*.S text eol=lf
+*.s text eol=lf

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -8,6 +8,8 @@
 #include "threads/flags.h"
 #include "intrinsic.h"
 #include "threads/synch.h"
+#include "threads/vaddr.h"
+#include "threads/mmu.h"
 
 #define NO_RETURN_VAL (-1)
 
@@ -43,6 +45,9 @@ static void handle_write (struct intr_frame *, struct syscall_entry *);
 static void handle_seek (struct intr_frame *, struct syscall_entry *);
 static void handle_tell (struct intr_frame *, struct syscall_entry *);
 static void handle_close (struct intr_frame *, struct syscall_entry *);
+static void *get_next_page_if_valid (void *ptr);
+static bool is_valid_user_buffer (void *buf, size_t size);
+static bool is_valid_user_string (char *str);
 
 /* 시스템 콜.
  *
@@ -243,4 +248,75 @@ static void
 handle_close (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 	barrier ();
 	ASSERT (false); /* 현재 처리할 수 없는 syscall */
+}
+
+static bool
+is_valid_user_buffer (void *buf, size_t size) {
+	void *p = buf;
+
+	if (size <= 0) {
+		return get_next_page_if_valid (p) != NULL;
+	}
+
+	/* 산술 연산 시에는 uintptr_t 변환이 안전해보임. */
+	void *buf_end = (void *) ((uintptr_t) p + size);
+	while (p < buf_end) {
+		/* 유효하면 다음 페이지, 아니면 NULL 반환. */
+		p = get_next_page_if_valid (p);
+		if (p == NULL) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool
+is_valid_user_string (char *str) {
+	char *p = str;
+
+	while (true) {
+		/* 유효하면 다음 페이지, 아니면 NULL 반환. */
+		char *next_p = get_next_page_if_valid (p);
+		char *page_end = pg_round_up (p);
+		if (next_p == NULL) {
+			return false;
+		}
+
+		/* 현재 페이지 내부를 순회하며 문자열의 끝이 있는지
+		   검사. */
+		while (p < page_end) {
+			if (*p == '\0') {
+				return true;
+			}
+			p++;
+		}
+
+		/* 다음 page 검사 진행. */
+		p = next_p;
+	}
+}
+
+/* 해당 ptr의 page가 유효한지 확인하고,
+   다음 페이지를 반환한다.
+   구현의 편의를 위해 분리한 함수다.
+   is_valid_user_* 외에는 사용하는 걸 추천하지 않음.
+   리턴하는 다음 페이지 주소가 유효하지 않을 수 있음.
+   유효 시 다음 page 주소를 반환한다.
+   그렇지 않으면 NULL을 반환한다. */
+static void *
+get_next_page_if_valid (void *ptr) {
+	if (ptr == NULL) {
+		return NULL;
+	}
+
+	/* 커널 영역 위인가? */
+	if (!is_user_vaddr (ptr)) {
+		return NULL;
+	}
+	/* thread가 가지는 유저 가상 주소(pml4 필드)가
+	   unmapped 상태인가? */
+	if (pml4_get_page (thread_current ()->pml4, ptr) == NULL) {
+		return NULL;
+	}
+	return (void *) (uintptr_t) pg_round_up (ptr);
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -318,5 +318,5 @@ get_next_page_if_valid (void *ptr) {
 	if (pml4_get_page (thread_current ()->pml4, ptr) == NULL) {
 		return NULL;
 	}
-	return (void *) (uintptr_t) pg_round_up (ptr);
+	return pg_round_up (ptr);
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -45,9 +45,9 @@ static void handle_write (struct intr_frame *, struct syscall_entry *);
 static void handle_seek (struct intr_frame *, struct syscall_entry *);
 static void handle_tell (struct intr_frame *, struct syscall_entry *);
 static void handle_close (struct intr_frame *, struct syscall_entry *);
-static void *get_next_page_if_valid (void *ptr);
-static bool is_valid_user_buffer (void *buf, size_t size);
-static bool is_valid_user_string (char *str);
+static void *get_next_page_if_valid (void *);
+static bool is_valid_user_buffer (void *, size_t);
+static bool is_valid_user_string (char *);
 
 /* 시스템 콜.
  *
@@ -253,13 +253,13 @@ handle_close (struct intr_frame *f UNUSED, struct syscall_entry *entry UNUSED) {
 static bool
 is_valid_user_buffer (void *buf, size_t size) {
 	void *p = buf;
+	/* 산술 연산 시에는 uintptr_t 변환이 안전해보임. */
+	void *buf_end = (void *) ((uintptr_t) p + size);
 
 	if (size <= 0) {
 		return get_next_page_if_valid (p) != NULL;
 	}
 
-	/* 산술 연산 시에는 uintptr_t 변환이 안전해보임. */
-	void *buf_end = (void *) ((uintptr_t) p + size);
 	while (p < buf_end) {
 		/* 유효하면 다음 페이지, 아니면 NULL 반환. */
 		p = get_next_page_if_valid (p);
@@ -282,8 +282,7 @@ is_valid_user_string (char *str) {
 			return false;
 		}
 
-		/* 현재 페이지 내부를 순회하며 문자열의 끝이 있는지
-		   검사. */
+		/* 현재 페이지 내부를 순회하며 문자열의 끝이 있는지 검사. */
 		while (p < page_end) {
 			if (*p == '\0') {
 				return true;
@@ -291,18 +290,17 @@ is_valid_user_string (char *str) {
 			p++;
 		}
 
-		/* 다음 page 검사 진행. */
+		/* 다음 페이지 검사 진행. */
 		p = next_p;
 	}
 }
 
-/* 해당 ptr의 page가 유효한지 확인하고,
-   다음 페이지를 반환한다.
-   구현의 편의를 위해 분리한 함수다.
-   is_valid_user_* 외에는 사용하는 걸 추천하지 않음.
-   리턴하는 다음 페이지 주소가 유효하지 않을 수 있음.
-   유효 시 다음 page 주소를 반환한다.
-   그렇지 않으면 NULL을 반환한다. */
+/* 해당 ptr의 페이지가 유효한지 확인하고,
+   유효 시 다음 페이지 주소를 반환, 그렇지 않으면 NULL을 반환한다.
+
+   구현의 편의를 위해 분리한 함수라서, is_valid_user_* 에서만 사용 추천
+   리턴하는 다음 페이지 주소가 유효하지 않을 수 있음을 주의하기
+   */
 static void *
 get_next_page_if_valid (void *ptr) {
 	if (ptr == NULL) {
@@ -313,10 +311,9 @@ get_next_page_if_valid (void *ptr) {
 	if (!is_user_vaddr (ptr)) {
 		return NULL;
 	}
-	/* thread가 가지는 유저 가상 주소(pml4 필드)가
-	   unmapped 상태인가? */
+	/* thread가 가지는 유저 가상 주소(pml4 필드)가 unmapped 상태인가? */
 	if (pml4_get_page (thread_current ()->pml4, ptr) == NULL) {
 		return NULL;
 	}
-	return (void *) (uintptr_t) pg_round_up (ptr);
+	return pg_round_up (ptr);
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -318,5 +318,5 @@ get_next_page_if_valid (void *ptr) {
 	if (pml4_get_page (thread_current ()->pml4, ptr) == NULL) {
 		return NULL;
 	}
-	return pg_round_up (ptr);
+	return (void *) (uintptr_t) pg_round_up (ptr);
 }


### PR DESCRIPTION
시스템 콜을 통한 사용자 메모리 접근 시, 메모리 주소를 신뢰할 수 없으므로 유효성 검사가 필수적입니다.

해당 작업을 수행하는 헬퍼 함수를 추가했습니다.

특정 시스템 콜 구현 시, 포인터의 종류에 따라 `is_valid_user_buffer()`, `is_valid_user_string()`를 호출하여 유효성 검사를 진행할 수 있습니다.

----

구현 방식을 설명하려면 virtual memory 구현까지 설명해야 해서 코어타임 때 설명 드릴게요.
