### PR TITLE
fix: process_exec 인자 페이지 해제 순서 수정

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -248,14 +248,16 @@ process_exec (void *f_name) {
 
 	/* 그런 다음 바이너리를 로드한다. */
 	success = load (argv[0], &_if);
-	palloc_free_page (file_name);
 
 	/* load에 실패했으면 종료한다. */
-	if (!success)
+	if (!success) {
+		palloc_free_page (file_name);
 		return -1;
+	}
 
 	setup_argument_stack (argv, argc, &_if);
 
+	palloc_free_page (file_name);
 	/* 전환된 프로세스를 시작한다. */
 	do_iret (&_if);
 	NOT_REACHED ();


### PR DESCRIPTION
## 변경 사항
- process_exec()에서 load() 직후 command page를 해제하던 흐름을 제거했습니다.
- load 실패 시에는 즉시 palloc_free_page(file_name) 후 반환합니다.
- load 성공 시 setup_argument_stack()이 argv 문자열을 사용자 스택으로 복사한 뒤 palloc_free_page(file_name)을 호출하도록 변경했습니다.

## 검증
- git diff --check
- process.c 단독 fsyntax-only 검사 통과