### PR TITLE
fix: userprog exec/wait 흐름 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -27,7 +27,7 @@ enum thread_status {
 typedef int tid_t;
 #define TID_ERROR ((tid_t) -1)          /* tid_t의 오류 값. */
 
-#ifndef USERPROG
+#ifdef USERPROG
 struct child_status {
 	tid_t tid;
 	int exit_status;
@@ -134,7 +134,7 @@ struct thread {
 	bool load_success;
 	int exit_status;
 
-#ifndef USERPROG
+#ifdef USERPROG
 	/* userprog/process.c가 소유합니다. */
 	uint64_t *pml4;                     /* 페이지 맵 레벨 4 */
 	struct thread *parent;

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -7,10 +7,12 @@
 #include <stdbool.h>
 #include "threads/fixed-point.h"
 #include "threads/interrupt.h"
+#include "threads/synch.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
 
+struct file;
 
 /* 스레드 수명 주기의 상태입니다. */
 enum thread_status {
@@ -25,10 +27,22 @@ enum thread_status {
 typedef int tid_t;
 #define TID_ERROR ((tid_t) -1)          /* tid_t의 오류 값. */
 
+#ifndef USERPROG
+struct child_status {
+	tid_t tid;
+	int exit_status;
+	bool waited;
+	bool exited;
+	struct semaphore wait_sema;
+	struct list_elem elem;
+};
+#endif
+
 /* 스레드 우선순위. */
 #define PRI_MIN 0                       /* 가장 낮은 우선순위. */
 #define PRI_DEFAULT 31                  /* 기본 우선순위. */
 #define PRI_MAX 63                      /* 가장 높은 우선순위. */
+#define FD_MAX 32
 
 /* 커널 스레드 또는 사용자 프로세스.
  *
@@ -116,9 +130,19 @@ struct thread {
 	fp32_t recent_cpu;
 	struct list_elem q_elem;
 
-#ifdef USERPROG
+	struct semaphore load_sema;
+	bool load_success;
+	int exit_status;
+
+#ifndef USERPROG
 	/* userprog/process.c가 소유합니다. */
 	uint64_t *pml4;                     /* 페이지 맵 레벨 4 */
+	struct thread *parent;
+	struct list children;
+	struct child_status *child_status;
+	struct file *running_file;
+	struct file *fd_table[FD_MAX];
+	int next_fd;
 #endif
 #ifdef VM
 	/* 스레드가 소유한 전체 가상 메모리에 대한 테이블입니다. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -145,6 +145,8 @@ thread_init (void) {
 	initial_thread->status = THREAD_RUNNING;
 	initial_thread->tid = allocate_tid ();
 
+	sema_init (&initial_thread->load_sema, 0);
+
 	if (thread_mlfqs)
 		list_push_back (&all_thread_list, &initial_thread->q_elem);
 }
@@ -528,7 +530,15 @@ init_thread (struct thread *t, const char *name, int priority) {
 	}
 	t->magic = THREAD_MAGIC;
 	t->wait_on_lock = NULL;
+	sema_init (&t->load_sema, 0);
 	list_init (&t->donations);
+#ifdef USERPROG
+	t->parent = NULL;
+	t->child_status = NULL;
+	t->running_file = NULL;
+	t->next_fd = 2;
+	list_init(&t->children)
+#endif
 }
 
 /* 예약할 다음 스레드를 선택하고 반환합니다. 해야 한다

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -537,7 +537,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->child_status = NULL;
 	t->running_file = NULL;
 	t->next_fd = 2;
-	list_init(&t->children)
+	list_init(&t->children);
 #endif
 }
 

--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -74,6 +74,7 @@ kill (struct intr_frame *f) {
 	   알려준다. */
 	switch (f->cs) {
 		case SEL_UCSEG:
+			thread_current ()->exit_status = -1;
 			/* 사용자 코드 세그먼트이므로 예상대로 사용자 예외다.
 			   사용자 프로세스를 종료한다. */
 			printf ("%s: dying due to interrupt %#04llx (%s).\n",

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -322,7 +322,7 @@ setup_argument_stack (char **argv, int argc, struct intr_frame *if_) {
  * 실패하면 -1을 반환한다. */
 int
 process_exec (void *f_name) {
-	char *cmd_line = f_name;
+	char *file_name = f_name;
 	char *argv[MAX_ARGC];
 	int argc;
 	bool success;
@@ -338,10 +338,9 @@ process_exec (void *f_name) {
 	/* 먼저 현재 컨텍스트를 제거한다. */
 	process_cleanup ();
 
-	char *argv[MAX_ARGC];
-	int argc = parse_command_line (cmd_line, argv);
+	argc = parse_command_line (file_name, argv);
 	if (argc == -1) {
-		palloc_free_page (cmd_line);
+		palloc_free_page (file_name);
 		return -1;
 	}
 
@@ -350,13 +349,13 @@ process_exec (void *f_name) {
 
 	/* load에 실패했으면 종료한다. */
 	if (!success) {
-		palloc_free_page (cmd_line);
+		palloc_free_page (file_name);
 		return -1;
 	}
 
 	setup_argument_stack (argv, argc, &_if);
 
-	palloc_free_page (cmd_line);
+	palloc_free_page (file_name);
 	/* 전환된 프로세스를 시작한다. */
 	do_iret (&_if);
 	NOT_REACHED ();

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -13,20 +13,33 @@
 #include "threads/flags.h"
 #include "threads/init.h"
 #include "threads/interrupt.h"
+#include "threads/malloc.h"
 #include "threads/palloc.h"
 #include "threads/thread.h"
 #include "threads/mmu.h"
 #include "threads/vaddr.h"
-#include "intrinsic.h"
 #include "threads/synch.h"
+#include "intrinsic.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
+
+static struct semaphore initd_wait_sema;
+
+struct fork_aux {
+	struct thread *parent;
+	struct intr_frame parent_if;
+	struct child_status *status;
+	struct semaphore start_sema;
+	struct semaphore done_sema;
+	bool success;
+};
 
 static void process_cleanup (void);
 static bool load (const char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
+static struct child_status *find_child_status (tid_t child_tid);
 
 #define MAX_ARGC 128
 
@@ -47,6 +60,7 @@ process_create_initd (const char *file_name) {
 	char *prog_name;
 	char *save_ptr;
 	tid_t tid;
+	sema_init (&initd_wait_sema, 0);
 
 	/* FILE_NAME의 복사본을 만든다.
 	 * 그렇지 않으면 호출자와 load() 사이에 경쟁 상태가 생긴다. */
@@ -92,8 +106,48 @@ initd (void *f_name) {
 tid_t
 process_fork (const char *name, struct intr_frame *if_ UNUSED) {
 	/* 현재 스레드를 새 스레드로 복제한다. */
-	return thread_create (name,
-			PRI_DEFAULT, __do_fork, thread_current ());
+	struct fork_aux *aux;
+	struct child_status *status;
+	tid_t tid;
+	
+	aux = malloc (sizeof *aux);
+	status = malloc (sizeof *status);
+	if (aux == NULL || status == NULL) {
+		free (aux);
+		free (status);
+		return TID_ERROR;
+	}
+
+	status->tid = TID_ERROR;
+	status->exit_status = -1;
+	status->waited = false;
+	status->exited = false;
+	sema_init (&status->wait_sema, 0);
+
+	aux->parent = thread_current ();
+	aux->parent_if = *if_;
+	aux->status = status;
+	aux->success = false;
+	sema_init (&aux->start_sema, 0);
+	sema_init (&aux->done_sema, 0);
+
+	list_push_back (&thread_current()->children, &status->elem);
+	tid = thread_create (name, PRI_DEFAULT, __do_fork, aux);
+	if (tid == TID_ERROR) {
+		list_remove (&status->elem);
+		free (status);
+		free (aux);
+		return TID_ERROR;
+	}
+
+	status->tid = tid;
+	sema_up (&aux->start_sema);
+	sema_down (&aux->done_sema);
+
+	if (!aux->success)
+		tid = TID_ERROR;
+	free (aux);
+	return tid;
 }
 
 #ifndef VM
@@ -108,20 +162,31 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	bool writable;
 
 	/* 1. TODO: parent_page가 커널 페이지라면 즉시 반환한다. */
+	if (is_kern_pte (pte))
+		return true;
 
 	/* 2. 부모의 페이지 맵 레벨 4에서 VA를 해석한다. */
 	parent_page = pml4_get_page (parent->pml4, va);
+	if (parent_page == NULL)
+		return true;
 
 	/* 3. TODO: 자식을 위한 새 PAL_USER 페이지를 할당하고 결과를
 	 *    TODO: NEWPAGE에 설정한다. */
+	newpage = palloc_get_page (PAL_USER);
+	if (newpage == NULL)
+		return false;
 
 	/* 4. TODO: 부모의 페이지를 새 페이지로 복제하고, 부모 페이지가 쓰기
 	 *    TODO: 가능한지 확인한다(결과에 따라 WRITABLE을 설정한다). */
+	memcpy (newpage, parent_page, PGSIZE);
+	writable = is_writable (pte);
 
 	/* 5. 새 페이지를 자식의 페이지 테이블에 VA 주소와 WRITABLE 권한으로
 	 *    추가한다. */
 	if (!pml4_set_page (current->pml4, va, newpage, writable)) {
 		/* 6. TODO: 페이지 삽입에 실패하면 오류 처리를 수행한다. */
+		palloc_free_page (newpage);
+		return false;
 	}
 	return true;
 }
@@ -132,18 +197,23 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
  *       즉, process_fork의 두 번째 인자를 이 함수에 전달해야 한다. */
 static void
 __do_fork (void *aux) {
+	struct fork_aux *fork_aux = aux;
 	struct intr_frame if_;
-	struct thread *parent = (struct thread *) aux;
+	struct thread *parent;
 	struct thread *current = thread_current ();
 	/* TODO: 어떤 방식으로든 parent_if를 전달한다. (즉, process_fork()의 if_) */
-	struct intr_frame *parent_if;
 	bool succ = true;
 
 	/* 1. CPU 컨텍스트를 로컬 스택으로 읽는다. */
-	memcpy (&if_, parent_if, sizeof (struct intr_frame));
+	sema_down (&fork_aux->start_sema);
+	parent = fork_aux->parent;
+	current->parent = parent;
+	current->child_status = fork_aux->status;
+	memcpy (&if_, &fork_aux->parent_if, sizeof if_);
+	if_.R.rax = 0;
 
 	/* 2. 페이지 테이블을 복제한다. */
-	current->pml4 = pml4_create();
+	current->pml4 = pml4_create ();
 	if (current->pml4 == NULL)
 		goto error;
 
@@ -163,12 +233,26 @@ __do_fork (void *aux) {
 	 * TODO:       성공적으로 복제하기 전까지 부모는 fork()에서 반환하면
 	 * TODO:       안 된다는 점에 유의하라. */
 
+	 for (int fd = 2; fd < FD_MAX; fd++) {
+		if (parent->fd_table[fd] != NULL) {
+			current->fd_table[fd] = file_duplicate (parent->fd_table[fd]);
+			if (current->fd_table[fd] == NULL)\
+				goto error;
+		}
+	 }
+	 current->next_fd = parent->next_fd;
+
 	process_init ();
+
+	fork_aux->success = succ;
+	sema_up (&fork_aux->done_sema);
 
 	/* 마지막으로 새로 생성한 프로세스로 전환한다. */
 	if (succ)
 		do_iret (&if_);
 error:
+	fork_aux->success = false;
+	sema_up (&fork_aux->done_sema);
 	thread_exit ();
 }
 
@@ -238,9 +322,9 @@ setup_argument_stack (char **argv, int argc, struct intr_frame *if_) {
  * 실패하면 -1을 반환한다. */
 int
 process_exec (void *f_name) {
-	ASSERT (f_name != NULL);
-
-	char *file_name = f_name;
+	char *cmd_line = f_name;
+	char *argv[MAX_ARGC];
+	int argc;
 	bool success;
 
 	/* thread 구조체 안의 intr_frame은 사용할 수 없다.
@@ -255,9 +339,9 @@ process_exec (void *f_name) {
 	process_cleanup ();
 
 	char *argv[MAX_ARGC];
-	int argc = parse_command_line (file_name, argv);
+	int argc = parse_command_line (cmd_line, argv);
 	if (argc == -1) {
-		palloc_free_page (file_name);
+		palloc_free_page (cmd_line);
 		return -1;
 	}
 
@@ -266,13 +350,13 @@ process_exec (void *f_name) {
 
 	/* load에 실패했으면 종료한다. */
 	if (!success) {
-		palloc_free_page (file_name);
+		palloc_free_page (cmd_line);
 		return -1;
 	}
 
 	setup_argument_stack (argv, argc, &_if);
 
-	palloc_free_page (file_name);
+	palloc_free_page (cmd_line);
 	/* 전환된 프로세스를 시작한다. */
 	do_iret (&_if);
 	NOT_REACHED ();
@@ -290,10 +374,36 @@ int
 process_wait (tid_t child_tid UNUSED) {
 	/* XXX: 힌트) process_wait(initd)에서 Pintos가 종료된다. process_wait를
 	 * XXX:       구현하기 전에는 여기에 무한 루프를 추가하는 것을 권장한다. */
-	for (int i = 1000000000; i >= 0; i--) {
-		barrier ();
+	struct child_status *status = find_child_status (child_tid);
+	int exit_status;
+
+	if (status != NULL) {
+		if (status->waited)
+			return -1;
+		status->waited = true;
+		sema_down (&status->wait_sema);
+		exit_status = status->exit_status;
+		list_remove (&status->elem);
+		free(status);
+		return exit_status;
 	}
-	return -1;
+
+	if (thread_current()->pml4 != NULL)
+		return -1;
+	sema_down (&initd_wait_sema);
+	return 0;
+}
+
+static struct child_status *find_child_status (tid_t child_tid) {
+	struct thread *curr = thread_current();
+	struct list_elem *e;
+
+	for (e = list_begin (&curr->children); e != list_end (&curr->children); e = list_next (e)) {
+		struct child_status *status = list_entry (e, struct child_status, elem);
+		if (status->tid == child_tid)
+			return status;
+	}
+	return NULL;
 }
 
 /* 프로세스를 종료한다. 이 함수는 thread_exit()에서 호출된다. */
@@ -304,7 +414,22 @@ process_exit (void) {
 	 * TODO: 프로세스 종료 메시지를 구현한다
 	 * TODO: (project2/process_termination.html 참고).
 	 * TODO: 여기에서 프로세스 리소스 정리를 구현하는 것을 권장한다. */
+	printf("%s: exit(%d)\n", curr->name, curr->exit_status);
+	if (curr->child_status != NULL) {
+		curr->child_status->exit_status = curr->exit_status;
+		curr->child_status->exited = true;
+		sema_up (&curr->child_status->wait_sema);
+	}
+	
+	for (int fd = 2; fd < FD_MAX; fd++) {
+		if (curr->fd_table[fd] != NULL) {
+			file_close (curr->fd_table[fd]);
+			curr->fd_table[fd] = NULL;
+		}
+	}
 
+	if (curr->parent == NULL)
+		sema_up(&initd_wait_sema);
 	process_cleanup ();
 }
 
@@ -312,6 +437,11 @@ process_exit (void) {
 static void
 process_cleanup (void) {
 	struct thread *curr = thread_current ();
+
+	if (curr->running_file != NULL) {
+		file_close (curr->running_file);
+		curr->running_file = NULL;
+	}
 
 #ifdef VM
 	supplemental_page_table_kill (&curr->spt);
@@ -503,11 +633,14 @@ load (const char *file_name, struct intr_frame *if_) {
 	/* TODO: 구현 내용을 여기에 작성한다.
 	 * TODO: 인자 전달을 구현한다(project2/argument_passing.html 참고). */
 
+	file_deny_write (file);
+	t->running_file = file;
 	success = true;
 
 done:
 	/* load 성공 여부와 관계없이 여기로 도착한다. */
-	file_close (file);
+	if (!success)
+		file_close (file);
 	return success;
 }
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -36,10 +36,10 @@ struct syscall_entry {
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 static void init_syscall_entry (struct intr_frame *, struct syscall_entry *);
-static void dispatch_syscall (struct syscall_entry *);
+static void dispatch_syscall (struct intr_frame *, struct syscall_entry *);
 static void handle_halt (struct syscall_entry *);
 static void handle_exit (struct syscall_entry *);
-static void handle_fork (struct syscall_entry *);
+static void handle_fork (struct intr_frame *, struct syscall_entry *);
 static void handle_exec (struct syscall_entry *);
 static void handle_wait (struct syscall_entry *);
 static void handle_create (struct syscall_entry *);
@@ -87,7 +87,7 @@ syscall_handler (struct intr_frame *f) {
 	struct syscall_entry entry;
 
 	init_syscall_entry (f, &entry);
-	dispatch_syscall (&entry);
+	dispatch_syscall (f, &entry);
 
 	if (entry.should_return_value) {
 		f->R.rax = entry.return_value;
@@ -108,7 +108,7 @@ init_syscall_entry (struct intr_frame *f, struct syscall_entry *entry) {
 }
 
 static void
-dispatch_syscall (struct syscall_entry *entry) {
+dispatch_syscall (struct intr_frame *f, struct syscall_entry *entry) {
 	switch (entry->syscall_num) {
 		case SYS_HALT:
 			handle_halt (entry);
@@ -117,7 +117,7 @@ dispatch_syscall (struct syscall_entry *entry) {
 			handle_exit (entry);
 			break;
 		case SYS_FORK:
-			handle_fork (entry);
+			handle_fork (f, entry);
 			break;
 		case SYS_EXEC:
 			handle_exec (entry);
@@ -174,29 +174,50 @@ static void
 handle_exit (struct syscall_entry *entry) {
 	int status = entry->args[0];
 
-	
+	exit_with_status(status);
 	exit_process (status);
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_fork (struct syscall_entry *entry UNUSED) {
-	barrier ();
-	ASSERT (false); /* 현재 처리할 수 없는 syscall */
+handle_fork (struct intr_frame *f, struct syscall_entry *entry UNUSED) {
+	const char *thread_name = (const char*) entry->args[0];
+
+	if (!is_valid_user_string(thread_name)) {
+		entry->return_value = -1;
+		return;
+	}
+	entry->return_value = process_fork (thread_name, f);
+	return;
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
 handle_exec (struct syscall_entry *entry UNUSED) {
-	barrier ();
-	ASSERT (false); /* 현재 처리할 수 없는 syscall */
+	const char *cmd_line = (const char *) entry->args[0];
+	char *cmd_copy;
+
+	if (!is_valid_user_string (cmd_line))
+		exit_with_status (-1);
+	
+	cmd_copy = palloc_get_page (0);
+	if (cmd_copy == NULL) {
+		entry->return_value = -1;
+		return;
+	}
+	strlcpy (cmd_copy, cmd_line, PGSIZE);
+
+	entry->return_value = process_exec (cmd_copy);
+	if (entry->return_value == -1) {
+		exit_with_status (-1);
+	}
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
 handle_wait (struct syscall_entry *entry UNUSED) {
-	barrier ();
-	ASSERT (false); /* 현재 처리할 수 없는 syscall */
+	entry->return_value = process_wait((tid_t) entry->args[0]);
+	return;
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
@@ -282,8 +303,16 @@ handle_tell (struct syscall_entry *entry UNUSED) {
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
 handle_close (struct syscall_entry *entry UNUSED) {
-	barrier ();
-	ASSERT (false); /* 현재 처리할 수 없는 syscall */
+	int fd = (int) entry->args[0];
+	struct thread *curr = thread_current();
+
+	if (fd >= 2 && fd < FD_MAX && curr->fd_table[fd] != NULL) {
+		file_close (curr->fd_table[fd]);
+		curr->fd_table[fd] = NULL;
+		if (fd < curr->next_fd)
+			curr->next_fd = fd;
+	}
+	return;
 }
 
 static bool

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -1,16 +1,20 @@
 #include "userprog/syscall.h"
 #include <stdio.h>
+#include <string.h>
 #include <syscall-nr.h>
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 #include "threads/loader.h"
+#include "threads/palloc.h"
 #include "userprog/gdt.h"
+#include "userprog/process.h"
 #include "threads/flags.h"
 #include "intrinsic.h"
 #include "threads/synch.h"
 #include "threads/vaddr.h"
 #include "threads/mmu.h"
 #include "lib/kernel/stdio.h"
+#include "filesys/file.h"
 #include "filesys/filesys.h"
 
 
@@ -159,7 +163,7 @@ dispatch_syscall (struct intr_frame *f, struct syscall_entry *entry) {
 
 static void
 exit_process (int status) {
-	printf ("%s: exit(%d)\n", thread_current ()->name, status);
+	thread_current ()->exit_status = status;
 	thread_exit ();
 }
 
@@ -174,13 +178,13 @@ static void
 handle_exit (struct syscall_entry *entry) {
 	int status = entry->args[0];
 
-	exit_with_status(status);
+	thread_current()->exit_status = status;
 	exit_process (status);
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_fork (struct intr_frame *f, struct syscall_entry *entry UNUSED) {
+handle_fork (struct intr_frame *f, struct syscall_entry *entry) {
 	const char *thread_name = (const char*) entry->args[0];
 
 	if (!is_valid_user_string(thread_name)) {
@@ -188,18 +192,20 @@ handle_fork (struct intr_frame *f, struct syscall_entry *entry UNUSED) {
 		return;
 	}
 	entry->return_value = process_fork (thread_name, f);
+	entry->should_return_value = true;
 	return;
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_exec (struct syscall_entry *entry UNUSED) {
+handle_exec (struct syscall_entry *entry) {
 	const char *cmd_line = (const char *) entry->args[0];
 	char *cmd_copy;
 
-	if (!is_valid_user_string (cmd_line))
-		exit_with_status (-1);
-	
+	if (!is_valid_user_string (cmd_line)) {
+		exit_process (-1);
+	}
+
 	cmd_copy = palloc_get_page (0);
 	if (cmd_copy == NULL) {
 		entry->return_value = -1;
@@ -209,14 +215,15 @@ handle_exec (struct syscall_entry *entry UNUSED) {
 
 	entry->return_value = process_exec (cmd_copy);
 	if (entry->return_value == -1) {
-		exit_with_status (-1);
+		exit_process (-1);
 	}
 }
 
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
-handle_wait (struct syscall_entry *entry UNUSED) {
+handle_wait (struct syscall_entry *entry) {
 	entry->return_value = process_wait((tid_t) entry->args[0]);
+	entry->should_return_value= true;
 	return;
 }
 


### PR DESCRIPTION
## 작업 배경

Pintos userprog 단계에서 `exec`, `wait`, `fork`, `exit` 흐름이 아직 실제 프로세스 생명주기와 동기화되지 않아 부모/자식 프로세스 간 종료 상태 전달, 로드 완료 대기, 파일 디스크립터 정리, 실행 파일 write deny 처리가 필요했습니다.

## 작업 내용

- `thread` 구조체에 부모/자식 프로세스 상태, 로드 동기화, 종료 상태, 실행 파일, 파일 디스크립터 테이블 정보를 추가했습니다.
- `fork` 시 부모 intr_frame과 페이지 테이블을 복제하고, 자식 생성 완료 여부를 세마포어로 동기화하도록 구현했습니다.
- `exec`, `wait`, `exit` syscall 흐름을 연결해 유저 문자열 검증, 커맨드라인 복사, 종료 상태 저장/전달, 중복 wait 방지, 프로세스 종료 메시지 출력을 처리했습니다.
- 프로세스 종료 시 열린 파일 디스크립터와 실행 파일 리소스를 정리하고, 실행 중인 파일에 대해 write deny를 적용했습니다.

## 테스트

- 미실행