### PR TITLE
update: syscall \ feat: halt pass

### DIFF
--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -188,12 +188,14 @@ static void
 handle_fork (struct intr_frame *f, struct syscall_entry *entry) {
 	const char *thread_name = (const char*) entry->args[0];
 
+	entry->should_return_value = true;
+
 	if (!is_valid_user_string(thread_name)) {
 		entry->return_value = -1;
 		return;
 	}
 	entry->return_value = process_fork (thread_name, f);
-	entry->should_return_value = true;
+	
 	return;
 }
 
@@ -202,6 +204,8 @@ static void
 handle_exec (struct syscall_entry *entry) {
 	const char *cmd_line = (const char *) entry->args[0];
 	char *cmd_copy;
+
+	entry->should_return_value = true;
 
 	if (!is_valid_user_string (cmd_line)) {
 		exit_process (-1);
@@ -223,8 +227,10 @@ handle_exec (struct syscall_entry *entry) {
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
 handle_wait (struct syscall_entry *entry) {
-	entry->return_value = process_wait((tid_t) entry->args[0]);
 	entry->should_return_value= true;
+	
+	entry->return_value = process_wait((tid_t) entry->args[0]);
+
 	return;
 }
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -13,6 +13,7 @@
 #include "threads/synch.h"
 #include "threads/vaddr.h"
 #include "threads/mmu.h"
+#include "threads/init.h"
 #include "lib/kernel/stdio.h"
 #include "filesys/file.h"
 #include "filesys/filesys.h"
@@ -171,8 +172,7 @@ exit_process (int status) {
 /* TODO: 구현하면 UNUSED, ASSERT 빼기 */
 static void
 handle_halt (struct syscall_entry *entry UNUSED) {
-	barrier ();
-	ASSERT (false); /* 현재 처리할 수 없는 syscall */
+	power_off();
 }
 
 static void


### PR DESCRIPTION
## 배경
- handle_halt 내부 구현이 안 되어 있음 ->  power_off 호출 해서 프로세스 강제 종료 필요
- handle_exec 함수 should_return_value 누락

## 변경 사항
- syscall.c : handle_halt 내부 power_off 함수 호출
- syscall.c : hadle_exec 내부 should_return_value 추가 및 다른  handle 함수 내부 호출 순서 변경