### PR TITLE
fix: USERPROG macro

### DIFF
--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -323,7 +323,8 @@ thread_exit (void) {
 	ASSERT (!intr_context ());
 
 #ifdef USERPROG
-	process_exit ();
+    if (thread_current ()->pml4 != NULL)
+        process_exit ();
 #endif
 
 	/* 상태를 죽어가는 것으로 설정하고 다른 프로세스를 예약하면 됩니다.
@@ -357,6 +358,8 @@ thread_yield_if_needed (void) {
 	if (list_empty (&ready_list))
 		return;
 
+	enum intr_level old_level = intr_disable ();
+
 	if (!thread_mlfqs) {
 		// Priority Donation 때문에 정렬 필요, list_pop_front를 해야하니까
 		list_sort (&ready_list, cmp_priority_more, NULL);
@@ -365,6 +368,8 @@ thread_yield_if_needed (void) {
 	struct thread *peek_t =
 		list_entry (list_front (&ready_list), struct thread, elem);
 	bool need_preemption = peek_t->priority > thread_current ()->priority;
+
+	intr_set_level (old_level);
 
 	if (need_preemption) {
 		if (intr_context ())
@@ -795,9 +800,9 @@ thread_mlfqs_recalc_priorities (void) {
 
 		e = list_next(e);
 	}
-
-	thread_yield_if_needed(); // 선점을 위해서, 우선순위 바뀌었으니까
 	intr_set_level (old_level);
+	
+	thread_yield_if_needed(); // 선점을 위해서, 우선순위 바뀌었으니까
 }
 
 static void


### PR DESCRIPTION
## 작업 배경

`userprog` 빌드에서 thread 테스트를 실행하면 커널 스레드 종료 시에도 `process_exit()`이 호출되어, 초기화되지 않은 user process 리소스와 semaphore 경로를 건드릴 수 있었습니다. 또한 MLFQS 우선순위 재계산 중 선점 판단이 인터럽트 복구 전에 수행되어 timer sleep 경로의 인터럽트 상태 assertion 실패로 이어질 수 있었습니다.

## 변경 사항

- `thread_exit()`에서 현재 스레드가 실제 user process 주소 공간(`pml4`)을 가진 경우에만 `process_exit()`을 호출하도록 조건을 추가했습니다.
- `thread_yield_if_needed()`에서 ready list와 priority 확인 구간을 인터럽트 비활성화로 보호하도록 조정했습니다.
- MLFQS 전체 우선순위 재계산 후 인터럽트 상태를 먼저 복구한 뒤 선점 판단을 수행하도록 순서를 변경했습니다.

## 테스트 방법

```bash
make -C "$PINTOS_ROOT/userprog" clean
make -C "$PINTOS_ROOT/userprog" check